### PR TITLE
docs: refresh to current product (16 builders, 7.5.x, new builders + features)

### DIFF
--- a/builders/beaver-builder.mdx
+++ b/builders/beaver-builder.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [Beaver Builder](https://www.wpbe
 
 [Beaver Builder](https://www.wpbeaverbuilder.com/) is a reliable, user-friendly WordPress page builder trusted by agencies and developers. It stores layouts as serialized data and features over 30 content modules with a focus on stability and clean code.
 
+Beaver Builder is full read and write. Respira builds, duplicates, batch-updates and renders native Beaver layouts, and mirrors every write to both the draft (`_fl_builder_data`) and published (`_fl_builder_data_published`) meta so the editor and the front end stay in lockstep.
+
 ## Data Structure
 
 Beaver Builder stores layouts as serialized PHP arrays in post meta (`_fl_builder_data`). The structure consists of rows, columns, and modules:
@@ -167,3 +169,9 @@ The `convert_html_to_builder` tool now fully supports Beaver Builder with:
 ### Support Level
 
 Beaver Builder has **Smart Defaults** support — element operations work via the generic tree utility with builder-specific content merging.
+
+## Recent capabilities (7.4.x)
+
+- **Compound settings no longer fatal on write.** Beaver reads compound settings (`border`, `place_content`, `typography`, `dimension` and friends) with array syntax, so Respira now coerces every compound setting value to a PHP array on the write path. That fixes duplicate, batch-update and page render in one place, where they previously could fatal with "Cannot use object of type stdClass as array."
+- **HTML-to-builder preserves section order on nested layouts.** Sections wrapping nested `<div>`s used to reorder because the converter produced invalid row-in-row structures. The Beaver hierarchy pass now emits valid `row > column-group > column > module` in source order, keeping multi-column grids intact.
+- **inject-builder-content accepts raw HTML** (a string, or `{ html: "..." }`), running it through the same converter `convert_html_to_builder` uses, so the two tools take the same input.

--- a/builders/breakdance.mdx
+++ b/builders/breakdance.mdx
@@ -11,7 +11,13 @@ Technical documentation for using Respira with the Breakdance WordPress page bui
 
 [Breakdance](https://breakdance.com/) is a visual WordPress site builder that stores layouts as structured JSON rather than shortcodes or raw HTML.
 
-Respira interacts with Breakdance pages at the JSON layer, updating content while preserving the existing layout and design.
+Respira interacts with Breakdance pages at the JSON layer, updating content while preserving the existing layout and design. Breakdance is full read and write: `build_page`, `inject_builder_content` (append and replace), and `update_element` all write native elements, with content landing at the native `properties.content.content.*` path the renderer reads and CSS regenerated after every write.
+
+## Recent capabilities (7.4.x)
+
+- **Content-path nesting and append-unwrap.** `inject_builder_content` with `mode:"append"` unwraps every wrapper shape Respira accepts (`children`, `elements`, `nodes`, `content`, `sections`, `modules`) before merging, and the validator walks with a running counter so a non-list array can never crash it. Content is nested one `content` level deeper for the element types whose content section is `content`, so text, headings and button labels render instead of falling back to defaults.
+- **Never-null structural fields are coerced (shared with Oxygen 6).** Oxygen 6.0.0 added a strict io-ts decoder that rejects `null` where it expects an object or array. Imported header, footer and template JSON often carries `"properties":null` or `"design":null`, which used to brick the editor site-wide. Respira's Oxygen 6 / Breakdance write path now coerces these to their empty shape (`properties` → `{}`, `design`/`content` → `[]`) on every persist, so imported templates do not brick the editor, and re-saving an affected template through any Respira edit repairs the null in place.
+- **Writes are verified against the database, not the object cache**, so a host with a persistent object cache cannot report a write that never reached the database.
 
 ## Data structure
 

--- a/builders/bricks.mdx
+++ b/builders/bricks.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [Bricks Builder](https://bricksbu
 
 [Bricks Builder](https://bricksbuilder.io/) is a modern, performance-focused WordPress page builder that stores content as lightweight JSON. It's known for clean code output, developer-friendly features, and over 80 elements. Respira has **full native support** for Bricks — including 20 dedicated Deep Intelligence tools that go beyond content editing into design system inspection, ACSS integration, query loops, and component management.
 
+Respira reads Bricks' real per-element control schemas (around 75 elements, the complete control set) so the agent knows what each element actually accepts. Ask for them with `get_builder_inline_schemas`. Every create path mints native 6-character element IDs that match Bricks' own `#brxe-` selectors, the `bricks_components` library is reachable, and CSS is regenerated on every write.
+
 ## Support Level
 
 Bricks has **Full Native Support** — the deepest integration level available in Respira:
@@ -270,6 +272,14 @@ Bricks global elements and templates are accessible through Respira:
 - [Page Builder Overview](/builders/overview) — Compare all supported builders
 
 ---
+
+## Recent capabilities (plugin v7.5.x)
+
+- **Real per-element control schemas.** A scanner captured every Bricks element's full runtime control schema (around 75 elements, the complete control set). The element registry and `get_builder_inline_schemas` now surface those real controls, so the agent builds against what each element accepts instead of guessing from names. Off-contract controls are flagged in the write notes (warn only, never rejected).
+- **Native 6-character element IDs everywhere.** Every create path — `build_page`, HTML convert, section presets, in-place inserts, and the pattern library — mints native 6-character IDs, so the editor's duplicate, copy, paste, and save work and front-end `#brxe-` selectors match.
+- **Component library reachable.** Respira reads the `bricks_components` option, so find/replace and the analyzers resolve component instances and a guarded patch path can edit a component definition with an automatic snapshot and rollback.
+- **CSS regenerated on writes**, so the front end reflects a change immediately without a manual rebuild.
+- **SEO, schema, and readability analyzers read Bricks content.** Bricks stores the page in postmeta rather than `post_content`; the analyzers now build analyzable HTML from the element tree, so they no longer report 0 words on a page that renders fine.
 
 ## v5.4.0 Elemental — Bricks Goes Deep
 

--- a/builders/brizy.mdx
+++ b/builders/brizy.mdx
@@ -11,7 +11,7 @@ Technical documentation for using Respira with [Brizy](https://www.brizy.io/).
 
 [Brizy](https://www.brizy.io/) is a modern WordPress page builder focused on simplicity and speed. It stores layouts as JSON and features over 40 elements with a clean, intuitive interface and cloud-based template library.
 
-**Write support (Respira 7.4.0 "Clearing"):** Brizy is full read and write. Respira writes pages the Brizy editor opens and the front end renders, verified on real installs. Front-end compile runs through Brizy's cloud compiler service, so the site needs internet for new pages to compile.
+**Write support (Respira 7.4.0 "Clearing"):** Brizy moved from read-only to full read and write in Respira 7.4.0. Respira writes pages the Brizy editor opens and the front end renders, verified on real installs. Front-end compile runs through Brizy's cloud compiler service, so the site needs internet for new pages to compile.
 
 ## Data Structure
 

--- a/builders/divi-5.mdx
+++ b/builders/divi-5.mdx
@@ -27,9 +27,9 @@ For the full prompting guide, see [Get Great Results: How to Prompt](/prompts). 
 - **Reuse existing presets and color tokens.** For brand consistency, tell the agent to read your existing Divi 5 presets and reuse them rather than inventing new colors.
 
 <details>
-<summary>Divi 5.7.4 caveat</summary>
+<summary>Divi 5 "Unknown Module" (fixed in the 7.4.x line)</summary>
 
-Some installs on **Divi 5.7.4** have reported an "Unknown Module" error on certain modules. If you hit it, do not retry the same write. Ask the agent to fall back to the core modules (heading, text, image, button, blurb) and to report the failing module name so it can be fixed. A schema fix for this is tracked separately.
+Older builds could produce an "Unknown Module" error when the agent invented layout names (`hero_section`, `feature_grid`, `cta_section`) instead of real Divi types. As of the 7.4.x releases Respira coerces any unrecognized type to the nearest native Divi block and warns the agent to use real `divi/` types, so an invented name no longer breaks the page. Best practice is still to ask for native Divi modules. If a specific module still fails on your Divi version, ask the agent to fall back to the core modules (heading, text, image, button, blurb) and report the failing module name.
 
 </details>
 

--- a/builders/divi-5.mdx
+++ b/builders/divi-5.mdx
@@ -54,6 +54,7 @@ Divi 5 support in Respira focuses on safe reading and editing of both layout for
 **Respira behavior**
 
 - Respira can read, edit, and save Divi 5 pages as blocks safely.
+- Respira builds real, editable modules from a 108-module catalog. Ask for the catalog with `get_builder_inline_schemas`.
 - Respira continues supporting Divi 4 pages by reading and writing the existing `et_pb_*` shortcodes.
 - Respira does not perform automatic conversion between these formats.
 
@@ -406,6 +407,15 @@ All `divi/*` modules accept a `settings` object with shorthand keys. Respira map
 > You can mix simplified `settings` with raw `attributes` in the same node. Settings are applied first, then any explicit `attributes` override them. Use `attributes` for Divi 5-specific features not covered by the simplified keys.
 
 ---
+
+## Recent capabilities (plugin v7.5.x)
+
+- **Native, editable module builds across a 108-module catalog.** `build_page` writes real `divi/*` modules from the catalog, discoverable through `get_builder_inline_schemas`, instead of falling back to a raw code block.
+- **Invented type names are coerced, not written verbatim.** An unmapped or made-up type name (for example `hero_section`) is coerced to the nearest native `divi/` block with a warning, so it no longer renders as a phantom "Unknown Module".
+- **Content lands in the bucket the renderer reads.** Loose content shapes are normalized into the `settings` bucket, so a module renders instead of coming back as an empty container.
+- **Custom CSS group recognized.** The universal `css` group is accepted on `update_module` instead of being flagged as an unknown group.
+- **Heading level fix.** A Heading only ever carries a valid `h1`–`h6` level, so Divi 5.7+ no longer refuses to render it.
+- **Background-overlay key fix**, so overlay settings apply as written.
 
 ## v5.2.0 Elemental — New Capabilities
 

--- a/builders/divi.mdx
+++ b/builders/divi.mdx
@@ -38,6 +38,8 @@ Use these resources for Divi 5 specific workflows:
 
 Divi 4 stores its builder layouts as `et_pb_*` shortcodes in `post_content`. Divi 5 uses block-based layouts where Divi modules appear as `divi/*` blocks in `post_content`. Respira works against both formats but does not perform the migration or conversion between them.
 
+On Divi 4, Respira parses the shortcode tree with a quote-aware attribute parser and folds alias children (rows and columns) into the right nesting, so a rebuild keeps the section, row, and column structure intact.
+
 Divi stores content as shortcodes in `post_content`:
 
 ```text
@@ -122,6 +124,14 @@ Respira detects Divi Global Modules. Updates to global modules appear everywhere
 - Visual-only settings (hover states) may need Divi builder
 - Per-module custom CSS is supported but complex styling may need builder
 - Dynamic content tokens are preserved but not directly editable
+
+## Recent capabilities (plugin v7.5.x)
+
+Divi 4 stays shortcode-based, and recent work hardened that path:
+
+- **Alias children fold correctly.** Row and column aliases now fold into the right nesting, so a full-page rebuild no longer drops rows or columns.
+- **Quote-aware attribute parser.** Shortcode attribute values that contain quotes or brackets (for example a `button_text` with punctuation) parse cleanly instead of truncating the shortcode.
+- **kses and `column_structure` corruption fixes.** Content-filtering and column-width edge cases that could corrupt a saved page are fixed, so an edited Divi 4 page renders as written.
 
 ## See also
 

--- a/builders/elementor.mdx
+++ b/builders/elementor.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [Elementor](https://elementor.com
 
 [Elementor](https://elementor.com/) is the leading WordPress page builder with over 16 million active installations. It provides a drag-and-drop interface for building pages using widgets, sections, and containers.
 
+Respira supports classic Elementor and Elementor v4 (Atomic). On v4, Respira writes around 20 element types (9 widgets plus 11 layout containers) with per-breakpoint and per-state styling. Types it does not yet support return a clear 422 error naming the unsupported type instead of dropping the element silently.
+
 ## Data Structure
 
 Elementor stores page layouts as structured JSON in WordPress post meta (`_elementor_data`). Each page contains a hierarchical tree of elements:
@@ -190,3 +192,11 @@ CSS custom properties (design tokens) can be converted to Elementor Global Color
 ### Support Level
 
 Elementor has **Full Intelligence** support — the highest tier, with dynamic schemas, element operations, HTML conversion, and settings validation.
+
+## Recent capabilities (plugin v7.5.x)
+
+- **Elementor v4 (Atomic) writes.** Respira writes around 20 v4 element types (9 widgets plus 11 layout containers) with per-breakpoint and per-state styling. Applied styles are wired to the element so they actually render.
+- **Clear errors on unsupported types.** A v4 element type Respira does not support yet returns a 422 error that names the type, instead of dropping it silently.
+- **Digit-leading style ids render.** A style id that starts with a digit (for example `1probedigit`) is sanitized to a valid letter-leading class, so Elementor generates a rule the browser matches and the element carries its style.
+- **Repeaters can shrink.** `update_element` can now remove entries from a repeater, not only add or change them.
+- **`_elementor_data` decode fixed** and `build_page` no longer drops v4 children, so a full-page build keeps every element. Per-page v4 auto-detect was also corrected so v4 pages are recognized as v4.

--- a/builders/flatsome.mdx
+++ b/builders/flatsome.mdx
@@ -5,7 +5,7 @@ description: 'AI-assisted editing for Flatsome, the most popular WooCommerce the
 
 # Flatsome UX Builder
 
-Flatsome is the #1 WooCommerce theme on ThemeForest with 200,000+ sales. Its editor, UX Builder, stores content as WordPress shortcodes in `post_content`. Respira 6.0 adds full support for Flatsome as Builder #12.
+Flatsome is the #1 WooCommerce theme on ThemeForest with 200,000+ sales. Its editor, UX Builder, stores content as WordPress shortcodes in `post_content`. Flatsome has full read and write support: extract, inject, `build_page`, element-level editing, snapshots and mixed-builder detection all work, backed by 55 element definitions and a set of page patterns, with WooCommerce shortcodes preserved through every write.
 
 ## How it works
 

--- a/builders/generateblocks.mdx
+++ b/builders/generateblocks.mdx
@@ -1,0 +1,54 @@
+---
+title: "GenerateBlocks"
+description: "How Respira reads and writes GenerateBlocks natively. GenerateBlocks is one of Respira's 16 supported page builders, edited as native WordPress blocks."
+---
+
+# GenerateBlocks
+
+Technical documentation for using Respira with [GenerateBlocks](https://generateblocks.com/).
+
+GenerateBlocks is a lightweight block library built around a small set of flexible blocks (container, grid, headline, button, text). It is one of Respira's 16 supported page builders, with full read and write.
+
+## Data Structure
+
+GenerateBlocks stores content as native WordPress blocks in `post_content`, the same as any Gutenberg page. GenerateBlocks carry the `generateblocks/*` (and `generateblocks-pro/*`) namespace:
+
+```html
+<!-- wp:generateblocks/container {"uniqueId":"a1b2c3"} -->
+  <!-- wp:generateblocks/headline {"uniqueId":"h1"} -->Welcome<!-- /wp:generateblocks/headline -->
+  <!-- wp:generateblocks/button {"uniqueId":"btn1"} -->Get Started<!-- /wp:generateblocks/button -->
+<!-- /wp:generateblocks/container -->
+```
+
+Because GenerateBlocks is block-based, Respira edits GenerateBlocks natively through the same path it uses for core Gutenberg blocks. There is no separate storage format to parse.
+
+## Priming
+
+Prime once at the start of a session so the agent builds and edits in blocks, not raw HTML:
+
+> *"This is a GenerateBlocks site. Build and edit with GenerateBlocks and core blocks, not raw HTML, and duplicate any live page before editing."*
+
+## What Respira can do
+
+- Read the full block structure of any GenerateBlocks page and report on it
+- Update text, headlines, and buttons inside GenerateBlocks (`generateblocks/headline`, `generateblocks/button`, `generateblocks/container`, `generateblocks/grid`, and the rest of the set)
+- Find blocks by type, content match, or block anchor
+- Add or remove sections while keeping the page editable in the block editor
+- Preserve all existing block attributes and styling on every write
+
+The workflow is the same as core Gutenberg because GenerateBlocks are namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
+
+## FAQ
+
+### Does Respira edit GenerateBlocks natively or convert them?
+
+Natively. Respira reads and writes GenerateBlocks in place through the WordPress block registry. Nothing is flattened to HTML and nothing is converted to a different builder.
+
+### Are GenerateBlocks Pro blocks supported?
+
+Yes. Both the free `generateblocks/*` and the `generateblocks-pro/*` blocks are read and written as native blocks.
+
+## See also
+
+- [Gutenberg (Block Editor)](/builders/gutenberg) - the shared block workflow
+- [Page Builder Overview](/builders/overview) - compare all 16 supported builders

--- a/builders/gutenberg.mdx
+++ b/builders/gutenberg.mdx
@@ -131,6 +131,10 @@ Example: "Update the site header tagline to 'Your Success Partner'"
 - **SEO and readability workflows** - Batch-fix heading hierarchy or missing alt text
 - **Programmatic content** - Update dates, years, or repeated content across pages
 
+## Recent capabilities (7.4.x)
+
+- **`build_page` no longer emits a non-existent `core/section` block.** A `section` type used to fall through to `core/section`, which WordPress renders as "This block is not supported" and the front end drops; `row` had the same gap. `section`/`container`/`wrapper` now map to `core/group` and `row` to `core/columns`, so a full-page build is valid, nested and renders. Native block support is otherwise full: Respira reads every registered block from the block registry, core and third-party alike.
+
 ## Limitations
 
 - **Block patterns**: Pattern structure is preserved, but pattern-specific styling may need the editor

--- a/builders/kadence-blocks.mdx
+++ b/builders/kadence-blocks.mdx
@@ -1,0 +1,58 @@
+---
+title: "Kadence Blocks"
+description: "How Respira reads and writes Kadence Blocks natively. Kadence Blocks is one of Respira's 16 supported page builders, edited as native WordPress blocks."
+---
+
+# Kadence Blocks
+
+Technical documentation for using Respira with [Kadence Blocks](https://www.kadencewp.com/kadence-blocks/).
+
+Kadence Blocks is a block library that adds layout containers, advanced buttons, forms, and design blocks to the WordPress block editor. It is one of Respira's 16 supported page builders, with full read and write.
+
+## Data Structure
+
+Kadence Blocks stores content as native WordPress blocks in `post_content`, the same as any Gutenberg page. Kadence blocks carry the `kadence/*` namespace:
+
+```html
+<!-- wp:kadence/rowlayout {"uniqueID":"123_abc"} -->
+  <!-- wp:kadence/column -->
+    <!-- wp:kadence/advancedheading -->Welcome<!-- /wp:kadence/advancedheading -->
+    <!-- wp:kadence/advancedbtn {"uniqueID":"btn1"} /-->
+  <!-- /wp:kadence/column -->
+<!-- /wp:kadence/rowlayout -->
+```
+
+Because Kadence is block-based, Respira edits Kadence blocks natively through the same path it uses for core Gutenberg blocks. There is no separate storage format to parse.
+
+One thing to note: Kadence layouts nest deeply (row layout, column, then inner blocks). Nested block editing round-trips byte-for-byte, so containers keep their children intact on every write.
+
+## Priming
+
+Prime once at the start of a session so the agent builds and edits in blocks, not raw HTML:
+
+> *"This is a Kadence Blocks site. Build and edit with Kadence and core blocks, not raw HTML, and duplicate any live page before editing."*
+
+## What Respira can do
+
+- Read the full block structure of any Kadence page and report on it
+- Update text, headings, and buttons inside Kadence blocks (`kadence/advancedheading`, `kadence/advancedbtn`, `kadence/rowlayout`, and the rest of the Kadence block set)
+- Find blocks by type, content match, or block anchor
+- Add or remove sections while keeping the page editable in the block editor
+- Preserve all existing block attributes and styling, including nested children, on every write
+
+The workflow is the same as core Gutenberg because Kadence blocks are namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
+
+## FAQ
+
+### Does Respira edit Kadence blocks natively or convert them?
+
+Natively. Respira reads and writes Kadence blocks in place through the WordPress block registry. Nothing is flattened to HTML and nothing is converted to a different builder.
+
+### Do nested Kadence row layouts survive editing?
+
+Yes. Nested blocks round-trip byte-for-byte, so a row layout keeps every column and inner block after an edit.
+
+## See also
+
+- [Gutenberg (Block Editor)](/builders/gutenberg) - the shared block workflow
+- [Page Builder Overview](/builders/overview) - compare all 16 supported builders

--- a/builders/overview.mdx
+++ b/builders/overview.mdx
@@ -23,9 +23,10 @@ Respira understands 16 WordPress page builders at the module level. AI can updat
 | [Thrive Architect](/builders/thrive-architect) | 40+ | Custom | Text edits |
 | [Breakdance](/builders/breakdance) | 130+ | JSON | ✓ Full |
 | [Flatsome UX Builder](/builders/flatsome) | 55+ | Shortcodes | ✓ Full |
-| Spectra | Blocks | Blocks | ✓ Full |
-| Kadence Blocks | Blocks | Blocks | ✓ Full |
-| GenerateBlocks | Blocks | Blocks | ✓ Full |
+| [Spectra](/builders/spectra) | Blocks | Blocks | ✓ Full |
+| [Kadence Blocks](/builders/kadence-blocks) | Blocks | Blocks | ✓ Full |
+| [GenerateBlocks](/builders/generateblocks) | Blocks | Blocks | ✓ Full |
+| [SeedProd](/builders/seedprod) | Blocks | Blocks | Audit only |
 
 > Divi covers Divi 4 and Divi 5; Oxygen covers Oxygen Classic and Oxygen 6. With those variants, that is **16 builders** with full read and write. SeedProd is audit-only (agents read and report on landing pages). Brizy and Visual Composer moved from read to write in Respira 7.4.0 "Clearing".
 

--- a/builders/overview.mdx
+++ b/builders/overview.mdx
@@ -93,7 +93,7 @@ Then: "Update the module labeled 'Hero CTA Button' to say 'Contact Us'"
 
 ### Which page builder has the best Respira support?
 
-All 12 supported builders have full module-level editing support. Divi and Elementor have the most comprehensive intelligence packages. Bricks has 20 dedicated deep tools. Flatsome has a 55-element intelligence package with nesting rules and page patterns.
+All 16 supported builders have full module-level editing support. Divi and Elementor have the most comprehensive intelligence packages. Bricks has 20 dedicated deep tools. Flatsome has a 55-element intelligence package with nesting rules and page patterns.
 
 ### Can Respira edit Global Modules in Divi?
 
@@ -101,7 +101,7 @@ Yes. Respira detects Divi Global Modules and can update them. Changes to global 
 
 ### Does Respira work with custom builder modules?
 
-Core modules from all 12 builders are fully supported. Third-party add-on modules have varying support depending on how they store data. Most text-based custom modules work well.
+Core modules from all 16 builders are fully supported. Third-party add-on modules have varying support depending on how they store data. Most text-based custom modules work well.
 
 ### What happens to my styling when Respira updates a module?
 

--- a/builders/oxygen.mdx
+++ b/builders/oxygen.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [Oxygen Builder](https://oxygenbu
 
 [Oxygen Builder](https://oxygenbuilder.com/) is a professional-grade WordPress site builder that generates clean, bloat-free code. It completely replaces your theme and offers full site building capabilities with over 60 components.
 
+Respira builds native, editable elements on both Oxygen Classic and Oxygen 6. On Oxygen 6 it emits real `OxygenElements` (and the rich `EssentialElements` when the "Breakdance Elements for Oxygen" add-on is active), not a single HTML block. Oxygen stores its tree in post meta, so writes are verified by reading the database rather than the object cache.
+
 ## Prompting for great results on Oxygen
 
 For the full prompting guide, see [Get Great Results: How to Prompt](/prompts). Oxygen has one failure mode worth naming:
@@ -164,3 +166,9 @@ Fixed: Oxygen templates using only `ct_builder_json` (without `ct_builder_shortc
 ### Support Level
 
 Oxygen has **Smart Defaults** support — element operations work via the generic tree utility.
+
+## Recent capabilities (7.4.x)
+
+- **Oxygen 6 builds native elements, not one HTML block.** Respira hands the agent the native Oxygen 6 element catalog on connect and builds real, editable `OxygenElements` (sections, headings, text, buttons, images), including the rich `EssentialElements` when the "Breakdance Elements for Oxygen" add-on is active. Sites without the add-on keep the safe core-only mapping.
+- **`build_page` accepts Oxygen 6's real elements.** Multi-element types the builder advertises (Columns, Column, Div, Grid, Accordion, Tabs, TextLink and more) validate against the same catalog `get_builder_info` reports, so a structured build is no longer refused with a 422 and forced into a code block.
+- **Writes are verified against the database, not the object cache**, so a persistent object cache cannot confirm a write that never reached the database.

--- a/builders/oxygen.mdx
+++ b/builders/oxygen.mdx
@@ -19,9 +19,9 @@ For the full prompting guide, see [Get Great Results: How to Prompt](/prompts). 
 - **Prime once at the start.** *"This is an Oxygen site. Build with native Oxygen components, not a code block. Read my site first, then give me a draft I can review."*
 
 <details>
-<summary>Oxygen 6 caveat</summary>
+<summary>Oxygen 6: native components (fixed in the 7.4.x line)</summary>
 
-On **Oxygen 6** specifically, the single-code-block fallback is the most-reported issue today. If you get "one block of code", that is the wrong path: re-prime the agent (*"use native Oxygen components, not a code block"*) and ask it to rebuild. A deeper Oxygen 6 fix is in progress; until it ships, priming plus the native-only instruction is the reliable workaround.
+Older Respira builds on **Oxygen 6** sometimes fell back to a single HTML or code block instead of native Oxygen elements. That is fixed as of the 7.4.x releases. Respira now hands the agent the native Oxygen 6 element catalog on connect and builds real, editable `OxygenElements` (sections, headings, text, buttons, images), including the rich `EssentialElements` when the "Breakdance Elements for Oxygen" add-on is active. If you are on an older plugin and still get one big code block, update to the latest release and re-prime the agent to use native Oxygen components.
 
 </details>
 

--- a/builders/seedprod.mdx
+++ b/builders/seedprod.mdx
@@ -1,0 +1,49 @@
+---
+title: "SeedProd"
+description: "How Respira reads and audits SeedProd landing pages. SeedProd is one of Respira's 16 supported page builders, read and audit only today."
+---
+
+# SeedProd
+
+Technical documentation for using Respira with [SeedProd](https://www.seedprod.com/).
+
+SeedProd is a landing-page and theme builder. It is one of Respira's 16 supported page builders. Today it is read and audit only: agents read SeedProd landing pages and report on them, and i haven't shipped write support for SeedProd yet.
+
+## Data Structure
+
+SeedProd is architecturally different from the block builders. A SeedProd landing page is stored as a `seedprod_lpage` custom post type, with the layout document held in the `seedprod_lpage_data` postmeta as proprietary JSON (a sections, rows, columns, blocks shape).
+
+Respira reads that structure. It walks the sections, rows, columns, and blocks so an agent can see what a landing page contains and describe it back to you. It does not write to that JSON, because SeedProd's serialization is not documented at attribute granularity and writing blind would risk corrupting a live landing page.
+
+## Priming
+
+Because SeedProd is read only today, prime the agent to audit rather than edit:
+
+> *"My landing pages are built with SeedProd. Read them and report on structure, copy, and SEO. Do not try to edit SeedProd pages directly."*
+
+## What Respira can do
+
+- Detect SeedProd landing pages on a site
+- Read the full section, row, column, and block structure of a landing page
+- Return the top-level layout outline so an agent can summarize a page
+- Report on copy, headings, and structure for review and SEO audits
+
+What Respira cannot do yet:
+
+- Write, update, or add blocks on a SeedProd landing page. Write operations return a clear "not supported" response with an agent-readable hint, so an agent knows to audit and report instead of editing blind.
+
+Native write support for SeedProd is on the roadmap for a follow-up release.
+
+## FAQ
+
+### Can Respira edit my SeedProd landing pages?
+
+Not yet. Respira reads and audits SeedProd pages today. i haven't shipped write support for SeedProd yet, so an agent can tell you what is on a page and flag issues, but it will not change the page. Write support is queued for a later release.
+
+### Can i still use Respira for the rest of my SeedProd site?
+
+Yes. The rest of your site, pages, posts, and any other supported builder, works normally with full read and write. Only SeedProd's own landing pages are read and audit only for now.
+
+## See also
+
+- [Page Builder Overview](/builders/overview) - compare all 16 supported builders

--- a/builders/spectra.mdx
+++ b/builders/spectra.mdx
@@ -1,0 +1,56 @@
+---
+title: "Spectra (Ultimate Addons for Gutenberg)"
+description: "How Respira reads and writes Spectra blocks natively. Spectra is one of Respira's 16 supported page builders, edited as native WordPress blocks."
+---
+
+# Spectra (Ultimate Addons for Gutenberg)
+
+Technical documentation for using Respira with [Spectra](https://wpspectra.com/), also known as Ultimate Addons for Gutenberg (UAG).
+
+Spectra is a block library that extends the WordPress block editor with advanced sections, containers, and design blocks. It is one of Respira's 16 supported page builders, with full read and write.
+
+## Data Structure
+
+Spectra does not use a separate storage format. Its blocks are stored as native WordPress blocks in `post_content`, the same as any Gutenberg page. Spectra blocks carry the `spectra/*` or `uagb/*` namespace:
+
+```html
+<!-- wp:uagb/container {"block_id":"a1b2c3"} -->
+  <!-- wp:uagb/advanced-heading {"headingTitle":"Welcome"} /-->
+  <!-- wp:uagb/buttons -->
+    <!-- wp:uagb/buttons-child {"label":"Get Started"} /-->
+  <!-- /wp:uagb/buttons -->
+<!-- /wp:uagb/container -->
+```
+
+Because Spectra is block-based, Respira edits Spectra blocks natively through the same path it uses for core Gutenberg blocks. There is no shortcode parsing or custom serialization in the middle.
+
+## Priming
+
+Prime once at the start of a session so the agent builds and edits in blocks, not raw HTML:
+
+> *"This is a Spectra (UAG) site. Build and edit with Spectra and core blocks, not raw HTML, and duplicate any live page before editing."*
+
+## What Respira can do
+
+- Read the full block structure of any Spectra page and report on it
+- Update text, headings, and buttons inside Spectra blocks (`uagb/advanced-heading`, `uagb/buttons`, `uagb/info-box`, and the rest of the Spectra block set)
+- Find blocks by type, content match, or block anchor
+- Add or remove sections while keeping the page editable in the block editor
+- Preserve all existing block attributes and styling on every write
+
+The workflow is the same as core Gutenberg because Spectra blocks are just namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
+
+## FAQ
+
+### Does Respira edit Spectra blocks natively or convert them?
+
+Natively. Respira reads and writes Spectra blocks in place through the WordPress block registry. Nothing is flattened to HTML and nothing is converted to a different builder.
+
+### What if a page has both Spectra and plain Gutenberg blocks?
+
+That is normal and fully supported. A page only registers as a Spectra page when it contains at least one `spectra/*` or `uagb/*` block. Either way, every block on the page stays editable.
+
+## See also
+
+- [Gutenberg (Block Editor)](/builders/gutenberg) - the shared block workflow
+- [Page Builder Overview](/builders/overview) - compare all 16 supported builders

--- a/builders/thrive-architect.mdx
+++ b/builders/thrive-architect.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [Thrive Architect](https://thrive
 
 [Thrive Architect](https://thrivethemes.com/architect/) is a conversion-focused WordPress page builder from Thrive Themes. It's designed for creating high-converting landing pages, sales pages, and opt-in forms with over 40 elements optimized for lead generation.
 
+Thrive Architect support is text-edit scope: Respira reads the page and makes targeted text updates to existing elements. Because Thrive's storage API is undocumented, it is safe text-level editing, not a full structural rebuild. Use it to change copy, headlines, button labels and links on existing elements, and lean on the visual builder for structural or design changes.
+
 ## Data Structure
 
 Thrive Architect stores layouts in a custom format with elements organized in a nested structure. Content is stored in post meta:

--- a/builders/visual-composer.mdx
+++ b/builders/visual-composer.mdx
@@ -11,7 +11,7 @@ Technical documentation for using Respira with [Visual Composer](https://visualc
 
 [Visual Composer](https://visualcomposer.com/) is a WordPress website builder that provides a frontend editor with 500+ elements and templates. Note: Visual Composer is different from WPBakery (formerly Visual Composer Page Builder). This reference covers the newer Visual Composer Website Builder.
 
-**Write support (Respira 7.4.0 "Clearing"):** Visual Composer is read and write. Respira writes in VC's canonical storage format, the editor loads the page, and the front end renders. VC regenerates its own compiled output the next time you save in its editor. Write coverage is broad but not yet exhaustive across every one of the 500+ elements.
+**Write support (Respira 7.4.0 "Clearing"):** Visual Composer moved from read-only to read and write in Respira 7.4.0. Respira writes in VC's canonical storage format, the editor loads the page, and the front end renders. VC regenerates its own compiled output the next time you save in its editor. Write coverage is broad but not yet exhaustive across every one of the 500+ elements.
 
 ## Data Structure
 
@@ -131,6 +131,11 @@ Visual Composer's global areas are editable:
 - **Animations**: Element animations are preserved but need the builder to modify
 - **Hub elements**: Third-party Hub elements have varying support
 - **Dynamic content**: Dynamic field connections are preserved but not directly editable
+
+## Recent capabilities (7.x)
+
+- **`update_element` applies edits as a deep settings patch.** The base-class write path (shared with Visual Composer) now normalizes an `updates` payload into a settings patch and deep-merges it, instead of a shallow merge at the element root that used to overwrite the whole `settings` dict and lose other styling keys.
+- **Successful meta writes are not misreported as no-ops.** Visual Composer stores its canonical tree in post meta, not `post_content`, so the write-noop check reads a storage-specific signature and no longer flags every successful write as a silent failure.
 
 ## When to Use This Tool
 

--- a/builders/wpbakery.mdx
+++ b/builders/wpbakery.mdx
@@ -11,6 +11,8 @@ Technical documentation for using Respira with [WPBakery Page Builder](https://w
 
 [WPBakery Page Builder](https://wpbakery.com/) (formerly Visual Composer) is one of the most widely used WordPress page builders with over 4 million active installations. It uses a shortcode-based architecture to store content.
 
+WPBakery is full read and write (read moved to write in Respira 7.4.0 "Clearing"). Respira builds, edits and round-trips shortcode layouts, and the same class handles the popular WPBakery forks: Uncode and TagDiv/Newspaper are recognized and their `uncode_*` / `tdb_*` shortcodes surface as first-class elements.
+
 ## Data Structure
 
 WPBakery stores layouts as nested shortcodes in `post_content`:
@@ -117,6 +119,13 @@ Respira works with content regardless of which editor was used. Both Backend Edi
 - **Custom CSS**: Per-element custom CSS is preserved but complex styling changes may require the builder
 - **Third-party add-ons**: Support varies; core WPBakery elements have full support
 - **Row/column structure**: Layout-level changes (column widths, row settings) are best done in the builder
+
+## Recent capabilities (7.x)
+
+- **Attribute round-trip is byte-faithful.** A pre-7.0.33 bug silently dropped every shortcode attribute on save (widths, media IDs, font tokens, `uncode_shortcode_id`) while reporting success. The write path now reads the attribute bag from any of `attrs` / `attributes` / `settings`, so extract-then-inject preserves every attribute.
+- **Per-shortcode attribute schemas at runtime.** `get_builder_inline_schemas` returns real per-shortcode schemas (`param_name`, type, heading, description, value, dependency, group) by reading WPBakery's `vc_map()` registry at runtime, cached for 1 hour, covering WPBakery, Uncode and TagDiv.
+- **`find_builder_targets` paginates.** Results carry `total_matches`, `offset`, `has_more` and `next_offset` so large pages page through cleanly.
+- **`_wpb_shortcodes_custom_css` is regenerated on every inject**, so Respira's REST writes (which run without an editor cap check) no longer leave stale per-post shortcode CSS that could break the front-end render on Uncode.
 
 ## When to Use This Tool
 

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -52,6 +52,52 @@ Not a WP-CLI replacement. WP-CLI is excellent for server-side WordPress administ
 
 ## WordPress Plugin Releases
 
+<Update label="2026-07" description="Respira for WordPress v7.5.x — ChatGPT connector + server-truth connectivity (latest v7.5.18)" tags={["release", "oauth", "chatgpt", "connectivity"]}>
+
+### What's New in the 7.5.x line
+
+The 7.5.x line is about connecting more AI apps with less friction, and about the plugin telling the truth about itself so a connected app never offers something this install cannot do. The current latest build is v7.5.18.
+
+**ChatGPT connector, no key to paste**
+- Unauthenticated MCP discovery so ChatGPT (and other apps that probe before signing in) can find your site's connector, then complete a one-time browser sign-in. You add the site by URL, approve access once, and a site-scoped token is minted. This matches the browser sign-in path Claude and the other apps already used.
+
+**Server truth, so connected apps stop guessing**
+- The plugin now declares which capabilities this exact install actually exposes, computed from the REST routes registered on it. A connected app can read that and hide tools whose route is not present, which removes the "no route" failures that happen when the AI app is newer than the installed plugin.
+- Connectivity and diagnostics improvements across the connect flow so a site that is reachable connects, and a site that is not says why.
+
+i haven't written a per-patch breakdown of every 7.5.x build here yet. If you want the exact notes for a specific version, ask and i will point you at it.
+
+</Update>
+
+<Update label="2026-06-21" description="Respira for WordPress v7.4.1 through v7.4.20 — builder-fix line" tags={["release", "builders", "writes", "fixes"]}>
+
+### What's New across 7.4.1 to 7.4.20
+
+A long run of builder fixes after "Clearing", each one verified on the matching builder on a real install. The theme is the same as 7.4.0: what the agent writes is what lands, and when it cannot land, Respira says so instead of reporting a false success.
+
+**Elementor**
+- Elementor v4 atomic style writes now wire to the element, so an explicit styles block, digit-leading style ids, and global system colours (primary, secondary, text, accent) all render instead of being generated and then worn by nothing.
+
+**Bricks**
+- Full control-schema deconstruction: a scanner captures every Bricks element's real runtime control set into a committed snapshot, so the agent knows what each element actually accepts, and off-contract controls are flagged with a "did you mean" instead of being dropped silently.
+- Bricks elements now mint the native 6-character ids the editor and front-end `#brxe-` selectors expect, Bricks Components survive a write with their `cid` and per-instance `properties` intact, and the SEO, schema, and readability checks now read Bricks content out of postmeta.
+
+**Oxygen 6**
+- Oxygen 6 now builds with its real native elements (`OxygenElements\*`), and picks up the rich `EssentialElements\*` Section, Heading, and Button blocks when the "Breakdance Elements for Oxygen" add-on is active, instead of collapsing a whole page into one HTML block. A legacy `null` that bricked the Oxygen 6 editor site-wide is coerced back to its empty shape on every save.
+
+**Divi 5**
+- Made-up layout names like `hero_section` no longer land as "Unknown Module" blocks: an unrecognised type is coerced to the nearest native `divi/` block, nested correctly, with a loud warning to use real Divi types. Loose content shapes agents actually send now normalise into native, editable, rendering modules, and the Visual Builder opens with the correct content after a Respira write.
+
+**Beaver Builder**
+- Compound settings (border, typography, dimension, and friends) are coerced to the array shape Beaver reads, so a render, duplicate, or batch update no longer fatals with "Cannot use object of type stdClass as array".
+
+**Self-correcting errors, less token waste**
+- When a locate, update, or patch operation cannot find its target, the response now hands the agent the page's actual elements to pick from (each with its path, id, type, admin_label, and a short content excerpt), so the agent picks the right one on its next call instead of guessing.
+
+This line also carried a critical site-down fix for Bedrock-style managed hosts (Kinsta and similar) on WordPress 6.9 and 7.0, where a bundled Abilities API polyfill could collide with the same class now shipping in core.
+
+</Update>
+
 <Update label="2026-06-12" description="Respira for WordPress v7.4.0 'Clearing' + MCP Server v7.2.1" tags={["release", "builders", "recovery", "writes"]}>
 
 ### What's New in 7.4.0 "Clearing"

--- a/configuration.mdx
+++ b/configuration.mdx
@@ -132,7 +132,7 @@ Restart Claude Code or Claude Desktop to load the configuration.
 
 ## Claude Cowork
 
-Configure Respira to work with [Claude Cowork](https://respira.press/cowork), the AI editing surface inside the Claude desktop app. The Cowork plugin is bundled with eight slash commands and 30 skills for WordPress editing without writing prompts.
+Configure Respira to work with [Claude Cowork](https://respira.press/cowork), the AI editing surface inside the Claude desktop app. The Cowork plugin is bundled with eight slash commands and 37 skills for WordPress editing without writing prompts.
 
 ### Install the Cowork plugin
 
@@ -165,7 +165,7 @@ If you prefer to be walked through it in chat, run `/respira:connect-site` insid
 ### What is bundled
 
 - **8 slash commands** including `/respira:connect-site`, `/respira:edit-page`, `/respira:undo-last-change`, `/respira:audit-site`, `/respira:duplicate-page`, `/respira:preview-changes`, `/respira:add-section`, `/respira:help`.
-- **30 skills** that auto-activate when the conversation matches: safety, page-builder detection, multi-site context, mobile experience report, technical debt audit, WooCommerce health check, SEO + AEO amplifier, internal link builder, image optimizer, 16 builder-to-builder migration recipes, and more.
+- **37 skills** that auto-activate when the conversation matches: safety, page-builder detection, multi-site context, mobile experience report, technical debt audit, WooCommerce health check, SEO + AEO amplifier, internal link builder, image optimizer, 16 builder-to-builder migration recipes, and more.
 - **1 visual reviewer sub-agent** that shows what changed after each edit.
 
 ### Troubleshooting

--- a/dashboard/accessibility.mdx
+++ b/dashboard/accessibility.mdx
@@ -82,6 +82,49 @@ respira scan accessibility https://example.com
 
 Same scanner, same report format, callable from any terminal where the CLI is installed.
 
+## Scanning from an AI agent
+
+The same WCAG scanner is available as MCP tools, so an agent connected to a site can scan, review, and fix accessibility issues in one conversation. Four tools cover the flow.
+
+### respira_scan_page_accessibility
+
+Run a WCAG scan on a page. The scanner runs an axe sweep against the page's public URL: `page_id` is resolved to the permalink server-side before the scan. The result groups violations by severity (critical, serious, moderate, minor) with auto-fix suggestions.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| page_id | number | Yes | Page ID to scan. Resolved to the page's public permalink before scanning. |
+| standard | string | No | WCAG standard to test against (default `wcag2aa`). Supported: `wcag2a`, `wcag2aa`, `wcag21a`, `wcag21aa`, `wcag22aa`, `section508`. |
+| url | string | No | Explicit URL override. When set, skips the page_id lookup. Use it for staging or preview URLs that do not map to a Respira page_id. |
+
+### respira_list_accessibility_scans
+
+List previous scans with scores and violation counts. It defaults to `summary_only=true`, which strips the per-node detail and the AI fix prompts from each entry. Those add up to roughly 30KB per scan and blow past the MCP response cap once you have five or more scans, so keep `summary_only` on for browsing and only set it to `false` when you genuinely need the full payload.
+
+| Parameter | Type | Required | Description |
+| --- | --- | --- | --- |
+| limit | number | No | Max scans to return (default 20). |
+| offset | number | No | Pagination offset (default 0). |
+| summary_only | boolean | No | When true (default), omits `violations[].nodes` and `prompts[]`. |
+
+### respira_get_accessibility_scan
+
+Get the full detail of one scan: every violation, the scores, and the AI fix prompts. Pass the `scan_id`, which is the UUID string from a `list_accessibility_scans` entry's `id` field. This is where you get the full payload that `list_accessibility_scans` leaves out in summary mode.
+
+### respira_apply_accessibility_fixes
+
+Auto-apply fixes for a scan. Pass the `scan_id`, and optionally a list of `rule_ids` to fix a subset; omit `rule_ids` to fix everything that is auto-fixable. The fixes it can apply are: `image-alt`, `color-contrast`, `label`, `heading-order`, `document-title`, and `html-lang-valid`.
+
+### A typical agent flow
+
+```text
+1. respira_scan_page_accessibility on page 42
+2. respira_get_accessibility_scan for the full violation detail
+3. respira_apply_accessibility_fixes for the auto-fixable rules
+4. respira_scan_page_accessibility again to confirm the score improved
+```
+
+Anything the auto-fixer cannot handle stays in the report for manual work, the same way the dashboard scanner leaves keyboard and screen-reader issues to human testing.
+
 ## Privacy
 
 Scans against public URLs are stored in our database with the URL, the report, and (if logged in) your account ID. We do not retain page content beyond the snapshot needed to render the report. Anonymous scans are rate-limited per IP and not associated with any account.

--- a/dashboard/connecting-your-site.mdx
+++ b/dashboard/connecting-your-site.mdx
@@ -11,11 +11,11 @@ Respira's auto-connect handshake is the fastest path from "plugin installed" to 
 
 ## Prerequisites
 
-- Respira for WordPress plugin **v6.10.1 or later** installed and activated on the site
+- Respira for WordPress plugin **v7.0 or later** installed and activated on the site (keeping it on the latest release is best)
 - A Respira account at [respira.press](https://www.respira.press) (free trial works)
 - Logged in to that account in the same browser you'll use for the handshake
 
-If your plugin is older than v6.10.1, update first via **Plugins → Updates** in WordPress, or download the latest from [respira.press/releases](https://www.respira.press/releases).
+If your plugin is older than v7.0, update first via **Plugins → Updates** in WordPress, or download the latest from [respira.press/releases](https://www.respira.press/releases).
 
 ## The handshake, step by step
 
@@ -60,7 +60,7 @@ The handshake can fail for a handful of reasons. The plugin and dashboard both l
 | Browser redirect lands on `respira.press/login?redirect=...` | You're not logged in to your Respira account | Log in, then click *Connect to Respira* again |
 | Plugin shows *handshake expired* after returning to wp-admin | The 10-minute single-use state token timed out before you completed the dashboard step | Click *Connect to Respira* again — generates a fresh token |
 | Dashboard shows the site as *Pending* even after success | A caching plugin or CDN is serving a stale wp-admin response | Purge the site's cache, then refresh the Respira dashboard |
-| Plugin redirects to wp-admin root instead of the Respira admin page | Older plugin version (pre-v6.10.1) had this bug | Update the plugin to v6.10.1 or later |
+| Plugin redirects to wp-admin root instead of the Respira admin page | An older plugin version had this bug | Update the plugin to the latest version |
 
 If none of those apply, the manual fallback below always works.
 

--- a/documentation.json
+++ b/documentation.json
@@ -266,6 +266,16 @@
                 "title": "MCP Tools Overview",
                 "path": "tools/overview",
                 "icon": "book-open"
+              },
+              {
+                "title": "Playbooks",
+                "path": "playbooks",
+                "icon": "repeat"
+              },
+              {
+                "title": "Team Accounts",
+                "path": "team-accounts",
+                "icon": "users"
               }
             ]
           },
@@ -370,6 +380,11 @@
                 "title": "wordpress_update_module",
                 "path": "tools/builders/update-module",
                 "icon": "sliders"
+              },
+              {
+                "title": "wordpress_get_page_outline",
+                "path": "tools/builders/get-page-outline",
+                "icon": "list-tree"
               }
             ]
           },
@@ -777,6 +792,11 @@
                 "title": "Divi 4 to Divi 5 Migration Guide",
                 "path": "guides/divi-4-to-divi-5",
                 "icon": "list-checks"
+              },
+              {
+                "title": "Host Blocks the Browser Connector",
+                "path": "guides/host-user-agent-block",
+                "icon": "shield-off"
               }
             ]
           },
@@ -977,6 +997,26 @@
               {
                 "title": "Flatsome",
                 "path": "builders/flatsome",
+                "icon": "layout"
+              },
+              {
+                "title": "Spectra",
+                "path": "builders/spectra",
+                "icon": "layout"
+              },
+              {
+                "title": "Kadence Blocks",
+                "path": "builders/kadence-blocks",
+                "icon": "layout"
+              },
+              {
+                "title": "GenerateBlocks",
+                "path": "builders/generateblocks",
+                "icon": "layout"
+              },
+              {
+                "title": "SeedProd",
+                "path": "builders/seedprod",
                 "icon": "layout"
               }
             ]

--- a/elementor-angie.mdx
+++ b/elementor-angie.mdx
@@ -17,7 +17,7 @@ It is a separate, curated integration intended for Elementor Angie workflows ins
 
 ## Requirements
 
-- Respira for WordPress `4.1.2+`
+- Respira for WordPress `7.0+` (latest release recommended)
 - Elementor with Angie available
 - Logged-in `wp-admin` session
 - Respira Angie integration enabled in plugin settings

--- a/guides/cloudflare-allowlist.mdx
+++ b/guides/cloudflare-allowlist.mdx
@@ -39,3 +39,4 @@ Many Cloudflare rule packs are designed to block bot traffic on the WordPress lo
 
 - `respira_diagnose_connection` — runs the same probes you would run by hand
 - `rest_route` fallback — what happens when WordPress rewrite rules also shadow `/wp-json` (different problem, separate doc)
+- [Host blocks the browser connector](/guides/host-user-agent-block) — when the origin host (WP Engine style) returns an nginx 403 on Claude's automated user agent, which Cloudflare changes will not fix

--- a/guides/host-user-agent-block.mdx
+++ b/guides/host-user-agent-block.mdx
@@ -1,0 +1,59 @@
+---
+title: Host blocks the browser connector (nginx 403 on an automated user agent)
+description: When the browser or ChatGPT connector fails at sign-in but the local connectors work, your host may be blocking Claude's automated user agent at the origin. How to confirm it, and the one fix.
+---
+
+# Host blocks the browser connector (nginx 403 on an automated user agent)
+
+Some managed hosts (WP Engine is the common one) block automated HTTP clients at the origin server, before the request ever reaches WordPress or the Respira plugin. Claude's servers fetch your site's sign-in files identifying as `python-httpx`, and a host that blocks that user agent returns a plain `403 Forbidden` from nginx. The browser connector then fails at the very first step, so it never reaches the sign-in screen.
+
+This is a different problem from a [Cloudflare block](/guides/cloudflare-allowlist). Cloudflare bot settings are not involved, and turning Cloudflare rules on or off will not fix it.
+
+## When this is your problem
+
+- The remote **browser connector** (claude.ai, or the Claude Desktop *custom connector by URL*, or the ChatGPT connector) fails with `mcp_registration_failed` or a start error before you ever see a sign-in page.
+- The site loads normally in a web browser.
+- The **local** connectors work fine: Claude Desktop (the one-click `.mcpb`), Claude Code, and Cursor all connect and edit your site. They run on your own computer with a user agent your host allows, so they are never blocked.
+
+If the local path already works for you, you are not stuck. You only need the fix below if you specifically want the browser/URL connector.
+
+## How to confirm it is your host, not Cloudflare
+
+Run this from any terminal, replacing the domain with your site:
+
+```bash
+curl -A "python-httpx/0.28.1" https://yoursite.com/.well-known/oauth-protected-resource
+```
+
+- If it returns the sign-in JSON (a short block starting with `{"resource":`), your host is not blocking and the problem is elsewhere.
+- If it returns a `403 Forbidden` whose body is a plain nginx page (`<center>nginx</center>`), your host is blocking the user agent at the origin. That is this problem.
+
+To be certain it is user-agent based, compare a browser-like agent, which should return `200`:
+
+```bash
+curl -A "Mozilla/5.0" https://yoursite.com/.well-known/oauth-protected-resource
+```
+
+A `200` for the browser agent and a `403` for `python-httpx` confirms the block is on the user agent, at your host, not on the path.
+
+## The fix
+
+The fix is a message to your host's support (for WP Engine, open a support ticket):
+
+> Please allow the paths `/.well-known/` and `/wp-json/respira/` through your platform user-agent blocking. An automated client (user agent `python-httpx`) is getting a 403 from nginx on those paths, and I need it allowed.
+
+The finish line is the same one-line test. Once it returns `200` instead of `403`, the connector completes on the next try:
+
+```bash
+curl -A "python-httpx/0.28.1" https://yoursite.com/.well-known/oauth-protected-resource
+```
+
+## While you wait
+
+You do not need the browser connector to start using Respira. On the [MCP Setup page](https://www.respira.press/dashboard/mcp), pick **Claude Desktop** (one-click) or **Claude Code** (one command). Both connect from your own computer with your key and are not affected by the host block.
+
+## Related
+
+- [Cloudflare allowlist for Respira routes](/guides/cloudflare-allowlist) — a separate edge block, on the HTTP method rather than the user agent
+- [Connect Claude Desktop (OAuth)](/connect-claude-desktop-oauth)
+- [Connect ChatGPT (OAuth)](/connect-chatgpt-oauth)

--- a/guides/multi-site-management.mdx
+++ b/guides/multi-site-management.mdx
@@ -15,6 +15,10 @@ You might have:
 - Staging site
 - A client site
 
+## Listing sites
+
+Use `wordpress_list_sites` to see every site in the current configuration and which one is active. It takes no arguments and is read-only, so it is the safe first call when you are not sure what is connected.
+
 ## Switching Sites
 
 Use [wordpress_switch_site](/tools/other/switch-site) to change the active site:
@@ -23,7 +27,19 @@ Use [wordpress_switch_site](/tools/other/switch-site) to change the active site:
 Switch to siteId "staging"
 ```
 
-Then run the rest of your tools normally (they’ll apply to the selected site).
+Then run the rest of your tools normally (they'll apply to the selected site). Switching flips the global current site for the configuration, so every later call in the session lands on the new site until you switch again.
+
+## Overriding the site for a single call
+
+Most tools also accept an optional `site_id` argument. Passing it overrides the active site for that one call without changing the global current site. This is the safest way to touch a different site once: you do not have to switch and remember to switch back.
+
+```text
+List the pages on siteId "staging" for this call only
+```
+
+This matters when one MCP server process runs several chats in parallel (for example multiple Cowork chats against different sites). A `switch_site` there would move the current site for every chat at once, so each chat should pin its own target with a per-call `site_id` instead of switching.
+
+A few tools do not take `site_id`, because a per-call override would not mean anything for them: `wordpress_list_sites`, `wordpress_get_active_site`, `wordpress_switch_site` (which already takes `site_id` to flip the global site), and `wordpress_redeem_token` (which runs before any site exists).
 
 ## Best Practices
 

--- a/inhale-mcp-abilities/about-mcp-and-anthropic.mdx
+++ b/inhale-mcp-abilities/about-mcp-and-anthropic.mdx
@@ -32,7 +32,7 @@ If you represent Anthropic, the WordPress Foundation, or any other rights holder
 
 ## About Respira
 
-Respira is an independent company that ships AI infrastructure for WordPress. Inhale: MCP Abilities is offered free; Respira's commercial work centers on **Respira for WordPress**, a paid safety layer for AI-driven edits across 12 page builders.
+Respira is an independent company that ships AI infrastructure for WordPress. Inhale: MCP Abilities is offered free; Respira's commercial work centers on **Respira for WordPress**, a paid safety layer for AI-driven edits across 16 page builders.
 
 Inhale: MCP Abilities and Respira for WordPress are technically and commercially separate. Inhale: MCP Abilities will continue to work whether or not you ever install Respira for WordPress.
 

--- a/inhale-mcp-abilities/faq.mdx
+++ b/inhale-mcp-abilities/faq.mdx
@@ -26,7 +26,7 @@ That said, treat the abilities you inhale the same way you'd treat any other API
 
 ## What's the relationship between Inhale: MCP Abilities and Respira?
 
-Inhale: MCP Abilities is a free utility built and maintained by Respira. Respira's main product is **Respira for WordPress**, a paid safety layer for AI-driven edits across 12 page builders (Elementor, Bricks, Divi, Breakdance, Oxygen, Beaver Builder, etc.).
+Inhale: MCP Abilities is a free utility built and maintained by Respira. Respira's main product is **Respira for WordPress**, a paid safety layer for AI-driven edits across 16 page builders (Elementor, Bricks, Divi, Breakdance, Oxygen, Beaver Builder, etc.).
 
 The two products are completely separate. You can use the Inhale: MCP Abilities plugin forever without ever using Respira for WordPress, and many users will. Inhale: MCP Abilities is offered to the WordPress community as a small contribution back to the ecosystem.
 

--- a/inhale-mcp-abilities/overview.mdx
+++ b/inhale-mcp-abilities/overview.mdx
@@ -26,7 +26,7 @@ Inhale: MCP Abilities is one of three layers Respira ships for WordPress:
 | Layer | What it is | Where it lives |
 |---|---|---|
 | **Inhale: MCP Abilities** | Free utility, choose which abilities are MCP-visible | Settings → Inhale: MCP Abilities |
-| **Respira for WordPress** | Paid plugin, safety layer for AI-driven edits across 12 page builders | Respira menu in wp-admin |
+| **Respira for WordPress** | Paid plugin, safety layer for AI-driven edits across 16 page builders | Respira menu in wp-admin |
 | **respira.press** | Marketing site and these docs | Public |
 
 You can run Inhale: MCP Abilities without ever installing Respira for WordPress. The two products are separate; Inhale: MCP Abilities is a community contribution.

--- a/installation.mdx
+++ b/installation.mdx
@@ -52,7 +52,7 @@ The fastest way is the auto-connect handshake. One click in WordPress admin, one
 
 A 2-minute screencast of the full flow on a fresh WordPress install: [Watch on YouTube →](https://www.youtube.com/watch?v=agzpWabYPZg).
 
-If auto-connect fails (firewall, SSO-locked admin, plugin pre-v6.10.1), use the manual fallback: copy the site token from **WordPress Admin → Respira → Settings**, then on the dashboard click *Add site manually* and paste the URL + token. Full troubleshooting: [Connecting Your Site](/dashboard/connecting-your-site).
+If auto-connect fails (firewall, SSO-locked admin, an outdated plugin), use the manual fallback: copy the site token from **WordPress Admin → Respira → Settings**, then on the dashboard click *Add site manually* and paste the URL + token. Full troubleshooting: [Connecting Your Site](/dashboard/connecting-your-site).
 
 <Callout kind="alert">
 MCP configs and site tokens grant access to connected sites. Treat them like passwords: never commit to git or paste into public chats/tickets.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -15,8 +15,8 @@ Respira is a safe bridge between your AI coding assistant and WordPress. It tran
 
 - Safely lets [Claude Cowork](https://respira.press/cowork), [Cursor](https://cursor.com), [Claude Code](https://claude.ai), [Windsurf](https://codeium.com/windsurf), and other AI coding assistants edit WordPress
 - Uses a duplicate-first workflow so AI edits copies; you approve before anything goes live
-- Understands 12 page builders: Divi, Elementor, Bricks, Oxygen, Gutenberg, WPBakery, Beaver Builder, Brizy, Visual Composer, Thrive Architect, Breakdance
-- 234 MCP tools including ACF (54 tools), element-level editing, page building, stock images, and tool governance (39 new in v5.2.0)
+- Understands 16 page builders, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd
+- 234 MCP tools including ACF (54 tools), element-level editing, page building, stock images, and tool governance
 - Requires no SSH or complex hosting setup—works on typical shared hosting
 
 ### Who this guide is for
@@ -161,7 +161,7 @@ You have successfully connected your AI coding assistant to WordPress.
 - [Configuration](/configuration)
 - [Usage Guide](/usage)
 - [Tools Reference](/tools/overview) - Tool categories, naming, and usage guidance
-- [Page Builder Support](/builders/overview) - How Respira works with 12 builders
+- [Page Builder Support](/builders/overview) - How Respira works with 16 builders
 - [Prompts & Examples](/prompts)
 - [Troubleshooting](/troubleshooting)
 
@@ -211,4 +211,4 @@ Yes. Respira offers a free trial. You can start without entering payment details
 
 ### Which page builders does Respira support?
 
-Respira supports 12 page builders: Gutenberg, Divi, Elementor, Bricks, Oxygen, WPBakery, Beaver Builder, Brizy, Visual Composer, Thrive Architect, and Breakdance.
+Respira supports 16 page builders, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd. See [Page Builder Support](/builders/overview) for the full matrix.

--- a/playbooks.mdx
+++ b/playbooks.mdx
@@ -1,0 +1,101 @@
+---
+title: "Playbooks"
+description: "Teach an agent a multi-step WordPress workflow once, then rerun it as a single callable Ability under the respira-playbooks/ namespace."
+---
+
+# Playbooks
+
+A Playbook is a typed JSON workflow that registers itself as a WordPress Ability and becomes a callable MCP tool. You author a repeatable workflow once, and every future run is a single tool call instead of an instruction-by-instruction agent session.
+
+Under the hood, the steps run server-side against Respira's own REST handlers. That means each step gets the same auth, audit trail, and snapshot protection as a direct agent call, and the whole run is one restorable snapshot session. The agent that invokes the Playbook sees a single typed result.
+
+## Why a Playbook
+
+A normal AI edit is the agent reasoning step by step: read the page, find the module, write the change, verify. That is flexible but slow and non-deterministic. Once you have a workflow you run often, "create a case study post", "publish a weekly digest", "mail-merge a service page", you want it to be:
+
+- one tool call, not a dozen
+- deterministic, so it does the same thing every time
+- typed, so the agent passes exactly the inputs it needs
+
+A Playbook crystallizes that workflow so the agent can just call it.
+
+## The tools
+
+| Tool | What it does |
+| --- | --- |
+| `respira_create_playbook` | Author a Playbook from an id, label, input schema, and an ordered list of steps. It registers as an Ability at `respira-playbooks/<id>`. |
+| `respira_list_playbooks` | List every Playbook stored on the site, with id, ability id, label, description, step count, invocation count, and last-invoked time. |
+| `respira_get_playbook` | Get one Playbook's full definition (input schema, steps, returns template, audit metadata). Read this before updating or invoking. |
+| `respira_update_playbook` | Modify an existing Playbook. The id is immutable; to change it, delete and recreate. Validation re-runs on the merged payload. |
+| `respira_delete_playbook` | Delete a Playbook. Its Ability drops out of the MCP catalog on the next handshake. Data created by past runs is left untouched. |
+
+## What a Playbook can and cannot do
+
+Steps reference MCP tools by name. Each step is `{ tool, args, capture? }`:
+
+- **tool** is an MCP tool name from the executor allowlist.
+- **args** are literal values plus templates. Use `{{input.x}}` to reference the Playbook's own inputs and `{{capture_name.field}}` to reference an earlier step's captured result.
+- **capture** is an optional name you bind a step's result under so later steps can read it.
+
+Destructive tools are refused at create time. `delete_*`, `restore_snapshot`, and `apply_builder_patch` cannot appear in a Playbook. If your flow needs one of those, split it out and have the agent call the destructive op directly.
+
+## Worked example: create a case study
+
+Author a Playbook that takes a client name and industry and produces a case study post.
+
+```json
+{
+  "id": "case-study-create",
+  "label": "Create Case Study",
+  "description": "Creates a case study post with client name and industry.",
+  "input_schema": {
+    "type": "object",
+    "properties": {
+      "client_name": { "type": "string" },
+      "industry": { "type": "string" }
+    },
+    "required": ["client_name"]
+  },
+  "steps": [
+    {
+      "tool": "respira_create_custom_post",
+      "args": {
+        "type": "post",
+        "title": "{{input.client_name}} case study",
+        "status": "draft",
+        "content": "How {{input.client_name}} works in {{input.industry}}."
+      },
+      "capture": "post"
+    }
+  ],
+  "returns": {
+    "post_id": "{{post.id}}",
+    "url": "{{post.link}}"
+  }
+}
+```
+
+The `capture: "post"` on the create step binds that step's result under the name `post`, so the `returns` template can pull `{{post.id}}` and `{{post.link}}` out of it.
+
+## Invoking a Playbook
+
+Once created, a Playbook is callable through `respira_invoke_ability` at the ability id `respira-playbooks/<id>`:
+
+```text
+respira_invoke_ability({
+  ability: "respira-playbooks/case-study-create",
+  args: { client_name: "AcmeBank", industry: "fintech" }
+})
+```
+
+Two things to keep in mind about invocation:
+
+- The wire field is `args`, never `input`. Respira binds the incoming `args` object under the name `input` inside the Playbook executor, which is why the step templates reference `{{input.client_name}}`.
+- Playbooks under the `respira-playbooks/` namespace skip the Inhale opt-in gate that other Abilities go through, because your own agent authored them on-site through `respira_create_playbook` (which already ran the destructive-tool refusal validator). Any other Ability still has to be inhaled from the Respira MCP Abilities screen before it can be invoked.
+
+Playbooks also appear in the streamable MCP `tools/list`, so a client sees them alongside the built-in tools.
+
+## Related
+
+- [respira_invoke_ability](/inhale-mcp-abilities/overview) — how Abilities are invoked
+- [Inhale MCP Abilities overview](/inhale-mcp-abilities/overview) — the opt-in gate Playbooks bypass

--- a/support/faq.mdx
+++ b/support/faq.mdx
@@ -49,4 +49,4 @@ To disable automatic update checks, set `RESPIRA_MCP_DISABLE_UPDATE_CHECK=1`.
 
 ## I hit Elementor 500 errors during updates. What should I do?
 
-Update to Respira for WordPress `4.2.0+` and MCP server `4.0.0+`. Recent releases include hardened payload handling, safer fallback writes, and improved structured diagnostics.
+Update to the latest Respira for WordPress plugin and MCP server. Recent releases include hardened payload handling, safer fallback writes, and improved structured diagnostics.

--- a/team-accounts.mdx
+++ b/team-accounts.mdx
@@ -1,0 +1,33 @@
+---
+title: "Team Accounts"
+description: "Put more than one person on a single Respira account, with a per-member access level enforced at token introspection."
+---
+
+# Team Accounts
+
+A team account lets more than one person work under a single Respira account. The team owns the licenses, and therefore the sites and packs. Members connect their own agents to those sites without needing their own separate subscription.
+
+Every existing account is already a team of one. Team features only surface once a second member is invited, and a single-user account behaves exactly as it did before.
+
+## How access works
+
+Each member has an access level. From the dashboard dropdown you pick one of three:
+
+- **read-only** — the member's agent is capped to read. It can inspect sites but not write.
+- **editor** — full read and write on the sites the member is granted.
+- **admin** — account-grade capabilities, with editor-level access to sites.
+
+The access level is enforced at token introspection. When a member's agent connects, Respira checks the member's live access level for the team that owns the site and hands the plugin the matching scope. The plugin only honors the scope introspection returns, so lowering someone to read-only takes effect on their next connection without any change to the plugin or the site keys. Changes land within the plugin's roughly one-minute introspection cache.
+
+## Per-member tokens
+
+A member's token keeps that member's own user id for revocation and audit, while pointing at the team's existing site and license. Two consequences follow from that:
+
+- Removing a member revokes only that member's tokens. The team's site-connection keys never rotate, so other members and the connected sites are unaffected.
+- Each member's MCP setup codes carry the team's sites through that member's own token. A member gets working setup codes for the team sites without the owner having to reshare a site key.
+
+## Related
+
+- [Multi-Site Management](/guides/multi-site-management) — working across the team's sites
+- [Team Workflows](/guides/team-workflows) — safe review patterns for teams
+- [API key management](/security/api-key-management) — how tokens and revocation work

--- a/tools/builders/get-page-outline.mdx
+++ b/tools/builders/get-page-outline.mdx
@@ -1,0 +1,61 @@
+---
+title: "wordpress_get_page_outline"
+description: "Lightweight row-level summary of a builder page's structure. Cheaper than extracting the full builder JSON."
+---
+
+# wordpress_get_page_outline
+
+Return a row-level outline of a builder page. This is a lighter read than `extract_builder_content`: instead of the full nested tree, you get one entry per top-level row so you can answer "what is the structure of this page" without walking the whole layout client-side.
+
+Works on every supported builder. Adapters with a dedicated outline implementation (WPBakery and Uncode today) return a richer per-row child-type histogram.
+
+## Parameters
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| pageId | number | Yes | Page or post ID |
+| builder | string | No | Builder name. Auto-detected from the active site builder when omitted. |
+
+## Response
+
+One entry per top-level row, each shaped like this:
+
+```json
+{
+  "success": true,
+  "outline": [
+    {
+      "index": 0,
+      "type": "et_pb_section",
+      "kind": "section",
+      "primary_heading": "Welcome",
+      "child_count": 3,
+      "child_types": ["et_pb_text", "et_pb_button", "et_pb_image"]
+    }
+  ]
+}
+```
+
+## Example Prompts
+
+- "What is the structure of the homepage?"
+- "Give me an outline of page 42 before we edit it"
+- "How many rows does the About page have and what is in each?"
+
+## When to use this vs extract_builder_content
+
+- Use **get_page_outline** first when you want the shape of a page: how many rows, what each one is, what it contains. It is the cheapest way to orient before an edit.
+- Use [wordpress_extract_builder_content](/tools/builders/extract-content) when you need the full builder-native JSON to modify and pass back into `inject_builder_content`.
+- For a targeted search by text or class, use `find_element` instead.
+
+If `extract_builder_content` runs into the response-size cap on a large page, the truncation hint points you back here: get the outline first, then extract just the subtree you care about.
+
+## Related Tools
+
+- [wordpress_extract_builder_content](/tools/builders/extract-content) - Full structured builder JSON
+- [wordpress_inject_builder_content](/tools/builders/inject-content) - Replace or append to the builder structure
+- [wordpress_update_module](/tools/builders/update-module) - Update a specific module
+
+## Notes
+
+- Read-only tool - doesn't modify content

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -38,13 +38,13 @@ npx @respira/wordpress-mcp-server --list
 npx @respira/wordpress-mcp-server --setup
 ```
 
-### Recommended version baseline (March 2026)
+### Recommended version baseline
 
-- Respira for WordPress: `5.2.0+`
-- MCP server: `5.2.0+`
-- WooCommerce tooling: plugin `5.2.0+`, MCP `5.2.0+`, Woo add-on `1.0.2+`
+- Respira for WordPress: `7.5+`
+- MCP server: `7.2+`
+- WooCommerce tooling: keep the WooCommerce add-on current alongside the plugin
 
-If you are on older versions, upgrade first before deep debugging.
+Respira ships fixes almost every week, so the reliable baseline is simply the latest release of each. If you are on older versions, update first before deep debugging.
 
 ### Gathering information for support
 
@@ -127,8 +127,7 @@ This is informational, not a runtime failure.
 
 If Elementor writes fail intermittently or return 500-level errors:
 
-- Upgrade Respira plugin to `4.2.0+`
-- Upgrade MCP server to `4.0.0+`
+- Update the Respira plugin and MCP server to the latest release
 - Re-run setup: `npx @respira/wordpress-mcp-server --setup`
 - Re-test: `npx @respira/wordpress-mcp-server --test`
 - Retry the same operation once after upgrade

--- a/usage.mdx
+++ b/usage.mdx
@@ -58,7 +58,7 @@ Respira for WordPress transforms how you interact with your WordPress site by pr
 
 ## Working with Page Builders
 
-Respira supports 12 page builders. Each builder stores content differently, but Respira handles the translation automatically.
+Respira supports 16 page builders. Each builder stores content differently, but Respira handles the translation automatically.
 
 ### Supported Builders
 

--- a/woocommerce/tools.mdx
+++ b/woocommerce/tools.mdx
@@ -376,7 +376,7 @@ If you run into issues with WooCommerce tools or need help designing workflows, 
 
 ## Complete tool list
 
-The add-on registers 53 WooCommerce abilities (namespace `respira-woocommerce/`), plus the REST/MCP storefront-design, catalog, pricing and AI-readiness tools described in the [overview](/woocommerce/overview). Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
+The add-on registers 54 WooCommerce tools: the `respira-woocommerce/` abilities plus the REST/MCP storefront-design, catalog, pricing and AI-readiness tools described in the [overview](/woocommerce/overview). Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
 
 ### Products, categories, tags & brands
 


### PR DESCRIPTION
Refreshes the docs to match the current product (plugin v7.5.18, MCP mcp-v7.2.13). The site had drifted several releases behind and contradicted itself on counts.

## Tier 1: correctness sweep
- Builder count is now 16 everywhere (was "12" in 9 places, while the overview already said 16). Skills 30 to 37. WooCommerce 53 to 54.
- Refreshed stale version baselines (5.2.0+/6.10.1/4.2.0+ etc.) to current or softened to "latest".
- Oxygen 6 and Divi 5 "Unknown Module" caveats rewritten from "fix in progress" to "fixed in the 7.4.x line" (confirmed against the plugin CHANGELOG).
- New page: `guides/host-user-agent-block.mdx` for the origin nginx-403-on-python-httpx block (WP Engine style), cross-linked from the Cloudflare guide. This is the exact failure a paying customer hit that the Cloudflare docs did not cover.

## Tier 2: capability + feature refresh
- Refreshed all 13 builder pages for 7.1 to 7.5 gains (Elementor v4 atomic writes, Bricks per-element schemas + native IDs, Divi 5 native build across a 108-module catalog, Oxygen 6 native elements, WPBakery attribute round-trip + vc_map schemas, Beaver compound settings, Brizy/VC moved to full write).
- Four new builder pages: Spectra, Kadence Blocks, GenerateBlocks (full read+write), SeedProd (audit-only).
- New feature docs: Playbooks, `get_page_outline`, Team Accounts; expanded multi-site (`site_id`) and accessibility scanning.
- Changelog brought current through v7.5.x.
- Nav wired for every new page; `documentation.json` validates and all 170 nav paths resolve.

## Notes for review
- Tool count kept at "234" and skills at "37" per decision. The live pricing page still shows "200+ tools / 35 skills"; the pricing page's 35 is the stale one (skills.json is 37), worth a bump there.
- The 7.5.x changelog entry is written from supplied release facts; this repo's source CHANGELOG only goes to 7.4.20.
- The docs corpus is heavy on em dashes (house style). New content matched it. A separate SOUL voice pass (no em dashes) could align the whole corpus later; not bundled here to keep this PR about freshness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
