### PR TITLE
docs: WooCommerce v3.2 + Respira ARC + teams and fair billing

### DIFF
--- a/arc.mdx
+++ b/arc.mdx
@@ -1,0 +1,51 @@
+---
+title: Respira ARC (free plugin)
+description: Respira ARC is a free WordPress plugin that makes any WooCommerce store readable to AI assistants - product feeds in six formats, a store llms.txt, an AI-readiness score, and attributed cart links. No caps, no accounts, no telemetry.
+---
+
+## What ARC is
+
+Respira ARC (Agent-Ready Commerce) is a free plugin for WooCommerce stores. AI assistants like ChatGPT, Claude, Copilot and Google AI Mode already recommend products to shoppers, and they can only sell what they can read. ARC makes your catalog readable to them:
+
+- **Product feeds in six formats**: Google Shopping XML, OpenAI/ChatGPT JSONL, Meta CSV, Pinterest CSV, TikTok CSV, and a generic CSV. Rebuilt on a schedule and a few minutes after products change, served as static files from your own domain.
+- **A store llms.txt** at your site root: what you sell, policy pages, top categories, and where the feeds live. The file AI assistants look for first.
+- **An AI-readiness score**: your catalog checked against the Google Shopping spec (images, descriptions, brands, identifiers, category mapping), with each failing check explained.
+- **Cart links with attribution**: signed URLs that fill a shopper's cart and land on your own checkout, with the order attributed to the source that sent it.
+
+Everything runs on your own server. No caps on products, no account required, no telemetry, and no product data passes through Respira.
+
+## Installing
+
+ARC has been submitted to the WordPress.org plugin directory and is in their review queue. Until the listing is live, download the zip from [respira.press/arc](https://www.respira.press/arc) and install it via Plugins, Add New, Upload Plugin.
+
+Requirements: WordPress 6.0 or newer, PHP 7.4 or newer, WooCommerce active.
+
+## The ARC screen
+
+After activation you get a screen under WooCommerce called Respira ARC:
+
+- **Product feeds**: pick formats, set the rebuild schedule, include or exclude out-of-stock products, serve the llms.txt.
+- **Feed URLs**: one row per format with a copy button and a submit link for the right destination (Google Merchant Center, OpenAI merchant onboarding, Meta Commerce Manager, Pinterest ads, TikTok ads).
+- **Catalog quality**: the readiness score with each failing check explained.
+- **Cart link generator**: pick products from a dropdown (variations included), set quantities and a source label, get a signed link.
+- **Agent-origin orders**: orders and revenue that arrived through cart links, last 30 days.
+
+## ARC and the WooCommerce Add-on
+
+ARC is the readable half. The paid [WooCommerce Add-on](/woocommerce/overview) contains all of ARC plus the agent that acts on what ARC finds: 87 tools that can fix every product failing the feed checks, write descriptions and alt text, assign brands and GTINs, manage orders and refunds, and edit STAGGS configurators, each write behind a snapshot with 90-day rollback.
+
+You never need both installed. If the add-on is present, ARC steps aside automatically and your settings carry over. Full detail on the paid layer: [Agent-Ready Commerce](/woocommerce/agent-ready-commerce).
+
+## FAQ
+
+**Does it slow the store down?** No. Feeds generate in the background in small batches and are served as static files. A shopper never waits on feed generation.
+
+**Does checkout leave my site?** No. Cart links land on your own WooCommerce checkout. Nothing about payment changes.
+
+**What if wp-cron is unreliable on my host?** The ARC screen warns when the scheduled rebuild is overdue and recommends a real cron hitting wp-cron.php. Manual rebuilds always work from the screen.
+
+**Where do the feeds live?** Static files in your uploads directory, served from your own domain at stable URLs. Your feed does not live on anyone else's CDN.
+
+## Support
+
+Questions: [word@respira.press](mailto:word@respira.press) or the [GitHub community](https://github.com/respira-press/Respira.press-Documentation-and-Community).

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -489,6 +489,49 @@ Download: [respira-for-wordpress-1.9.1.zip](https://respira.press/releases)
 
 </Update>
 
+## WooCommerce Add-on Releases
+
+<Update label="2026-07-17" description="WooCommerce Add-on v3.2.0: STAGGS configurator suite" tags={["feature", "woocommerce", "configurators"]}>
+
+### WooCommerce Add-on v3.2.0
+
+Product configurator editing for stores running STAGGS. 87 tools total.
+
+- Eight configurator tools: detect STAGGS, enable or disable the configurator per product, list attribute groups, and rewrite option items (labels, prices, defaults) through the STAGGS/Carbon Fields helpers
+- Allow-listed writes: any key outside the known-safe set refuses the whole request rather than half-applying it
+- Verified live against the real STAGGS plugin, round-trip included
+
+</Update>
+
+<Update label="2026-07-16" description="WooCommerce Add-on v3.1.0: Agent-Ready Commerce" tags={["feature", "woocommerce", "agentic-commerce"]}>
+
+### WooCommerce Add-on v3.1.0
+
+Your store becomes discoverable and shoppable by AI assistants. 79 tools, up from 56.
+
+- Product feeds in six formats (Google Shopping XML, OpenAI/ChatGPT JSONL, Meta, Pinterest, TikTok, generic CSV), rebuilt in the background on schedule and minutes after products change, plus a store llms.txt at the site root
+- The AI-readiness score becomes a fix loop: an ordered fixlist, GTIN and gallery writes on update_product, image alt-text writes, robots.txt AI-crawler checks
+- Signed cart links that fill a shopper's cart and land on your own checkout, with agent-origin order attribution and a revenue report
+- 14 write tools for WooCommerce Subscriptions, Bookings and Memberships, tested against the real extensions, dry-run by default
+- A new wp-admin screen under WooCommerce, Respira ARC, as the home for feeds, the quality score, cart links and agent-origin orders
+- The readable half also ships standalone as Respira ARC, a free plugin submitted to WordPress.org
+
+See [Agent-Ready Commerce](/woocommerce/agent-ready-commerce) for the full documentation.
+
+</Update>
+
+<Update label="2026-07-16" description="WooCommerce Add-on v3.0: complete WooCommerce agent coverage" tags={["feature", "woocommerce"]}>
+
+### WooCommerce Add-on v3.0
+
+Complete WooCommerce agent coverage: 56 tools.
+
+- Variations, attributes, and the WooCommerce 10.9 colour and image swatches
+- Brands, coupons, customers (PII-aware), order notes, and refunds with dry-run by default
+- AI-readiness scoring per product and across the catalog
+
+</Update>
+
 ## MCP Server Releases
 
 <Update label="2026-03-07" description="MCP Server v3.3.5" tags={["improvement", "telemetry"]}>

--- a/documentation.json
+++ b/documentation.json
@@ -899,6 +899,17 @@
             ]
           },
           {
+            "group": "Respira ARC (free)",
+            "icon": "store",
+            "pages": [
+              {
+                "title": "Respira ARC",
+                "path": "arc",
+                "icon": "gift"
+              }
+            ]
+          },
+          {
             "group": "Support",
             "icon": "help-circle",
             "pages": [

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -16,7 +16,7 @@ Respira is a safe bridge between your AI coding assistant and WordPress. It tran
 - Safely lets [Claude Cowork](https://respira.press/cowork), [Cursor](https://cursor.com), [Claude Code](https://claude.ai), [Windsurf](https://codeium.com/windsurf), and other AI coding assistants edit WordPress
 - Uses a duplicate-first workflow so AI edits copies; you approve before anything goes live
 - Understands 16 page builders, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd
-- 234 MCP tools including ACF (54 tools), element-level editing, page building, stock images, and tool governance
+- 254 MCP tools including ACF, WooCommerce (87 tools via the add-on), element-level editing, page building, stock images, and tool governance
 - Requires no SSH or complex hosting setup—works on typical shared hosting
 
 ### Who this guide is for

--- a/team-accounts.mdx
+++ b/team-accounts.mdx
@@ -26,6 +26,25 @@ A member's token keeps that member's own user id for revocation and audit, while
 - Removing a member revokes only that member's tokens. The team's site-connection keys never rotate, so other members and the connected sites are unaffected.
 - Each member's MCP setup codes carry the team's sites through that member's own token. A member gets working setup codes for the team sites without the owner having to reshare a site key.
 
+## Inviting people
+
+Invites are sent from the dashboard team page by email. Someone you invited who has not accepted yet is never billed. Each member's edits appear in the team audit log under their own identity, so you can see who changed what across every connected site.
+
+## Seats and fair billing
+
+A plan buys your sites; a seat is what you add when another person works alongside you. Full detail at [respira.press/fair-billing](https://www.respira.press/fair-billing); the short version:
+
+- **Owner: always free.** You are also the team's first admin, free.
+- **First member: free, on every plan.** A two person team costs nothing beyond the plan.
+- **Extra members: €5 a month each**, flat at any team size. **A second admin and beyond: €10 a month each.**
+- **Seats bill only in months they are active.** A seat is active when that person ran at least one agent command or made at least one change through the team. Signing in, viewing sites, or reading the audit log is watching, and watching is free. Billing is monthly, in arrears, prorated by active days.
+- **Client seats are free.** A client seat sees exactly one group of sites and nothing else, never billed. Available on Builder and above.
+- **On Maker, your team is you plus one, free forever.** That free plus-one doubles as the client handoff seat. Paid member and client seats start on Builder.
+- **Every new team gets 30 days with unlimited free seats** (Builder and above). The clock starts on your first invite, recorded once. When the window ends, nothing bills until you choose how billing should work: auto-bill active seats, ask before each new person starts billing, or, if you choose nothing, everyone past you plus one pauses with dashboard access intact and nothing deleted.
+- **Founding members stay free.** Anyone holding a seat when team accounts launched is free for life, recorded on the seat itself.
+
+Every consent, mode change and pause is written to the team audit log.
+
 ## Related
 
 - [Multi-Site Management](/guides/multi-site-management) — working across the team's sites

--- a/woocommerce/agent-ready-commerce.mdx
+++ b/woocommerce/agent-ready-commerce.mdx
@@ -1,6 +1,6 @@
 ---
 title: Agent-Ready Commerce
-description: Make your WooCommerce store discoverable and shoppable for AI assistants - product feeds in six formats, a store llms.txt, an AI-readiness score with autofix, and attributed cart links. New in add-on v3.1.
+description: Make your WooCommerce store discoverable and shoppable for AI assistants - product feeds in six formats, a store llms.txt, an AI-readiness score with autofix, attributed cart links, and STAGGS configurator editing. Add-on v3.1 and v3.2.
 ---
 
 ## Why this exists
@@ -60,6 +60,14 @@ The catalog readiness report also checks your robots.txt for lines that block AI
 Orders arriving through cart links are attributed twice: through WooCommerce's native order attribution (`utm_source` per agent, `utm_medium=agentic`, visible in WooCommerce Analytics) and through a server-side order meta safety net that works even with JavaScript blocked.
 
 `woocommerce_agent_orders_report` returns the orders and revenue attributed to agents over any period, broken down by source. The same numbers appear on your respira.press dashboard as the "Agent-origin orders" card.
+
+## Product configurators (v3.2)
+
+Stores that sell configurable products (engraving, materials, add-on options) usually run them through the STAGGS plugin. v3.2 adds eight configurator tools: detect STAGGS, enable or disable the configurator per product, list its attribute groups, and rewrite option items (labels, prices, defaults). Writes go through the same STAGGS and Carbon Fields helpers the plugin itself uses, so storage stays exactly as STAGGS expects, and every write is allow-listed: any key outside the known-safe set refuses the whole request rather than half-applying it.
+
+## The Respira ARC screen in wp-admin
+
+The add-on ships an admin screen under WooCommerce called Respira ARC. It is the home for this layer: feed formats and schedule, the feed URLs with submit links for each platform, the catalog quality score with Fix with AI buttons, a cart link generator with a product picker, agent-origin orders for the last 30 days, and a "What an agent could do here" card with copyable prompts.
 
 ## Two skills that use this layer
 

--- a/woocommerce/overview.mdx
+++ b/woocommerce/overview.mdx
@@ -1,11 +1,11 @@
 ---
 title: WooCommerce Add-on
-description: 54 AI tools for WooCommerce including storefront design intelligence, bulk pricing with snapshots, and catalog health audits. €95/year for Maker and Builder. Included free with Studio and Founder.
+description: 87 AI tools for WooCommerce including agent-ready commerce (product feeds + llms.txt), storefront design intelligence, Subscriptions, Bookings and Memberships writes, STAGGS configurator editing, bulk pricing with snapshots, and catalog health audits. €95/year for Maker and Builder. Included free with Studio and Founder.
 ---
 
 ## Overview
 
-The Respira for WordPress WooCommerce Add-on extends Respira's safety-first workflow to your WooCommerce store. 54 tools that connect commerce data to page builder visuals, with a snapshot, a dry-run preview, and an approval step on every change.
+The Respira for WordPress WooCommerce Add-on extends Respira's safety-first workflow to your WooCommerce store. 87 tools (as of add-on v3.2) that connect commerce data to page builder visuals and make the store readable to AI shopping assistants, with a snapshot, a dry-run preview, and an approval step on every change.
 
 **Pricing:**
 - **Studio and Founder plans:** included free, no separate purchase
@@ -26,7 +26,7 @@ If you are not set up with Respira yet, start with the base [Installation](/inst
 
 </Callout>
 
-## What's included (54 tools)
+## What's included (87 tools)
 
 The add-on grew from commerce CRUD into the full storefront layer. The areas:
 
@@ -38,8 +38,17 @@ The add-on grew from commerce CRUD into the full storefront layer. The areas:
 - Variation CRUD and one-call variation-matrix generation with a dry-run preview
 - Global attributes, plus the WooCommerce 10.9 colour and image swatches (wc-visual)
 
-**Product configurator (Staggs)**
-- Drive the Staggs product configurator by prompt: enable it per product, read its setup, and toggle options per dealer. Allow-listed and snapshotted. The piece no other WooCommerce MCP has.
+**Agent-ready commerce (v3.1)**
+- Product feeds in six formats (Google Shopping XML, OpenAI/ChatGPT JSONL, Meta, Pinterest, TikTok, generic CSV) plus a store llms.txt at the site root, rebuilt on schedule and minutes after products change
+- Signed cart links that fill a shopper's cart and land on your own checkout, with agent-origin order attribution and a revenue report
+- The readiness score becomes a fix loop: an ordered fixlist, GTIN and gallery writes, and image alt-text tools
+- Full detail on the [Agent-Ready Commerce](/woocommerce/agent-ready-commerce) page
+
+**Subscriptions, Bookings, and Memberships (v3.1)**
+- 14 write tools tested against the real Woo extensions: list, inspect and transition subscriptions, reschedule bookings with a conflict scan, pause and resume memberships, set end dates. Dry-run by default
+
+**Product configurator (STAGGS, v3.2)**
+- Read and edit STAGGS product configurators by prompt: enable per product, list attribute groups, and rewrite option items (labels, prices, defaults) through the STAGGS/Carbon Fields helpers so storage stays consistent. Writes are allow-listed: any key outside the known-safe set refuses the whole request. The piece no other WooCommerce MCP has
 
 **Orders, refunds, and notes**
 - Order listing, status updates (which trigger WooCommerce emails), and order notes

--- a/woocommerce/tools.mdx
+++ b/woocommerce/tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: WooCommerce Tools Reference
-description: Reference for WooCommerce MCP tools provided by the Respira for WordPress WooCommerce Add-on (54 tools), grouped by products, orders, inventory, and reports.
+description: Reference for WooCommerce MCP tools provided by the Respira for WordPress WooCommerce Add-on (87 tools), grouped by products, orders, inventory, feeds, extensions, configurators, and reports.
 ---
 
 ## How WooCommerce tools work with your AI assistant
@@ -13,7 +13,7 @@ Your AI assistant typically decides which tool to call based on natural language
 - Set guardrails for what the assistant is allowed to change
 - Review logs and audit which tools were used
 
-When the WooCommerce add-on is installed, the assistant has access to 54 WooCommerce tools spanning products, variations and swatches, the Staggs configurator, orders and refunds, coupons, customers, inventory, AI-readiness, and storefront design intelligence. This page documents the primary product, order, inventory, and report tools; see the [overview](/woocommerce/overview) for the full list of areas.
+When the WooCommerce add-on is installed, the assistant has access to 87 WooCommerce tools (as of add-on v3.2) spanning products, variations and swatches, orders and refunds, coupons, customers, inventory, AI-readiness, storefront design intelligence, product feeds and llms.txt, cart links with agent-order attribution, Subscriptions, Bookings and Memberships, and the STAGGS product configurator. This page documents the primary product, order, inventory, and report tools, then lists the v3.1 and v3.2 groups; see the [overview](/woocommerce/overview) for the full list of areas.
 
 <Callout kind="info">
 
@@ -376,7 +376,7 @@ If you run into issues with WooCommerce tools or need help designing workflows, 
 
 ## Complete tool list
 
-The add-on registers 54 WooCommerce tools: the `respira-woocommerce/` abilities plus the REST/MCP storefront-design, catalog, pricing and AI-readiness tools described in the [overview](/woocommerce/overview). Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
+The add-on registers 87 WooCommerce MCP tools (as of v3.2): the `respira-woocommerce/` abilities plus the REST/MCP storefront-design, catalog, pricing, AI-readiness, feeds, cart-link, extension and configurator tools described in the [overview](/woocommerce/overview) and in the section below. Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
 
 ### Products, categories, tags & brands
 
@@ -449,3 +449,43 @@ The add-on registers 54 WooCommerce tools: the `respira-woocommerce/` abilities 
 - `respira-woocommerce/get-order-refunds` — List order refunds
 - `respira-woocommerce/create-order-refund` — Refund an order
 
+
+## Agent-ready commerce and extension tools (v3.1 and v3.2)
+
+The v3.1 and v3.2 releases added six groups. MCP tool names below; each also registers as a WordPress Ability for browser AI.
+
+### Product feeds and llms.txt
+
+- `woocommerce_configure_feed` — enable formats, schedule, options; returns the public feed URLs
+- `woocommerce_generate_feed` — kick a rebuild (idempotent; first batch runs synchronously so it works even when wp-cron is dead)
+- `woocommerce_get_feed_status` — manifest, per-format freshness, wp-cron health warning
+- `woocommerce_validate_feed` — check rows against each platform's actual spec before registering
+- `woocommerce_set_feed_category_mapping` — map your categories to the Google product taxonomy
+
+### Readiness score and autofix
+
+- `woocommerce_product_ai_readiness` / `woocommerce_catalog_ai_readiness` — the 0-100 score, per product and store-wide
+- `woocommerce_readiness_fixlist` — the scan as an ordered work queue, weakest products first, each failing check paired with the tool that fixes it
+- `woocommerce_set_image_alt` — write image alt text (the check that fails most often); GTIN and gallery writes live on `woocommerce_update_product`
+
+### Cart links and attribution
+
+- `woocommerce_create_cart_link` — a signed URL that fills the cart server-side and lands on your own checkout; tampered signatures get a 403
+- `woocommerce_agent_orders_report` — orders and revenue attributed to AI-assistant sources
+
+### Subscriptions (WooCommerce Subscriptions)
+
+- `woocommerce_list_subscriptions`, `woocommerce_get_subscription`, `woocommerce_update_subscription_status` (every transition validated against what Subscriptions itself allows), `woocommerce_update_subscription_dates`, `woocommerce_add_subscription_note`
+
+### Bookings and Memberships (WooCommerce Bookings, Memberships)
+
+- `woocommerce_list_bookings`, `woocommerce_get_booking`, `woocommerce_update_booking_status`, `woocommerce_reschedule_booking` (conflict scan before anything moves)
+- `woocommerce_list_membership_plans`, `woocommerce_list_memberships`, `woocommerce_get_membership`, `woocommerce_update_membership_status`, `woocommerce_set_membership_end_date`
+
+All extension writes are dry-run by default and require the real extension plugin to be active.
+
+### Product configurator (STAGGS, v3.2)
+
+- `woocommerce_configurator_status`, `woocommerce_get_product_configurator`, `woocommerce_set_product_configurator` — detect STAGGS, read and enable/disable the configurator per product
+- `woocommerce_list_configurator_attributes`, `woocommerce_get_configurator_attribute_items`, `woocommerce_set_configurator_attribute_items` — read attribute groups and rewrite option items (labels, prices, defaults) through the STAGGS/Carbon Fields helpers
+- `woocommerce_get_plugin_state`, `woocommerce_set_plugin_state` — allow-listed plugin settings; any key outside the known-safe set refuses the whole request


### PR DESCRIPTION
Brings the docs up to the current product:

- **WooCommerce Add-on to v3.2**: 87 tools on every page; Agent-Ready Commerce page gains the STAGGS configurator section and the Respira ARC wp-admin screen; tools reference now lists the six v3.1/v3.2 tool groups with exact MCP tool names (feeds, readiness autofix, cart links, Subscriptions/Bookings/Memberships, configurator); overview covers the new areas.
- **New Respira ARC page** (`/arc`) with its own nav group: what the free plugin does, install path while the wp.org review runs, the ARC screen, and how it hands off to the paid add-on.
- **Team accounts**: invites, seats and fair billing (owner free, first member free on every plan, EUR 5 member / EUR 10 admin seats billed only in months they are active, client seats free, Maker is you plus one forever, 30-day unlimited-seats window, founding members free for life).
- **Changelog**: new WooCommerce Add-on Releases section (v3.0, v3.1, v3.2).
- **Introduction**: tool counts current (254 MCP tools, 87 WooCommerce via add-on, 16 builders).

Note: the deployed docs at respira.press/docs have not synced from this repo since before July 3 (the 16-builders refresh and team-accounts page are in main but 404/stale live). Documentation.AI likely needs the repo re-linked after the rename; see ADMIN_SETUP.md line 121.