### PR TITLE
docs: 7.6.0 tool counts + Theme Builder & WPML tools

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ description: Quick start guide for connecting Respira for WordPress to AI coding
 
 Respira for WordPress connects your AI coding assistant to your site so you can safely edit, inspect, and manage content using natural language. It provides a controlled workflow that keeps your live site protected while enabling fast, precise changes through tools like [Cursor](https://cursor.com), [Claude Code](https://claude.ai), and [Windsurf](https://codeium.com/windsurf).
 
-Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow and expose 234 tools depending on your add-ons and runtime.
+Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow and expose 260 MCP tools plus 228 WebMCP abilities depending on your add-ons and runtime.
 
 ## What is Respira for WordPress?
 

--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -5,7 +5,7 @@ description: "Reference for current Respira MCP tools. Find the right tool for p
 
 # Tools Reference
 
-Respira provides 234 MCP tools for AI assistants to interact with WordPress. This reference documents the core categories and naming patterns.
+Respira provides 260 MCP tools for AI assistants to interact with WordPress (173 in every core plan, plus 87 in the WooCommerce add-on), alongside 228 WebMCP browser abilities. This reference documents the core categories and naming patterns.
 
 ## Tool Categories
 
@@ -203,6 +203,22 @@ Quick single-element additions without building full page structures.
 
 Full ACF and ACF Pro coverage: field reads/writes, field group management, repeater and flexible-content operations, galleries, options pages, relationships, user/term fields, and bulk operations across up to 500 posts. See [ACF tools overview](/tools/acf/overview) for the full list and example workflows.
 
+### Theme Builder — Divi (3 tools) <span style={{color: '#10b981'}}>NEW in 7.6</span>
+
+Discover and edit Divi's global Theme Builder templates (headers, footers, and body layouts), not just regular pages. List the templates on a site, edit a header in place (for example to build a mega menu), or create a new global template with page assignments. Every edit is snapshot-protected. Divi 5.
+
+- `respira_list_theme_builder_templates` (read)
+- `respira_create_theme_builder_template` (write)
+- `respira_update_theme_builder_template` (write)
+
+### Translations — WPML (3 tools) <span style={{color: '#10b981'}}>NEW in 7.6</span>
+
+Create and update WPML translations through the agent. A created translation joins the page's existing language group so WPML treats it as a real translation, and the builder content is carried across into the new copy.
+
+- `respira_get_translations` (read)
+- `respira_create_translation` (write)
+- `respira_update_translation` (write)
+
 ## Quick Reference Table
 
 | Category | Tools | Read-Only | Write |
@@ -230,8 +246,12 @@ Full ACF and ACF Pro coverage: field reads/writes, field group management, repea
 | ACF (v6.6.0) | 54 | 18 | 36 |
 | Bricks deep tools | 20 | 8 | 12 |
 | Elementor deep tools | 8 | 5 | 3 |
+| Theme Builder — Divi <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
+| Translations — WPML <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
 | WooCommerce (add-on) | 21 | 11 | 10 |
-| **Total** | **234** | **96** | **138** |
+| **Total** | **240** | **98** | **142** |
+
+> This table lists the documented core categories. The full MCP surface is **260 tools** (173 in core plans plus 87 in the WooCommerce add-on) alongside **228 WebMCP browser abilities** — see the live counts on [respira.press](https://respira.press).
 
 ## Tool Naming Convention
 


### PR DESCRIPTION
Aligns headline tool counts to the site canonical (260 MCP tools, 228 WebMCP abilities) and documents the six new 7.6.0 tools: Theme Builder (Divi) list/create/update and WPML translations get/create/update. Adds two category sections + quick-reference rows + a reconciling note.