### PR TITLE
docs: 7.6.1 mega menu + counts

### DIFF
--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ description: Quick start guide for connecting Respira for WordPress to AI coding
 
 Respira for WordPress connects your AI coding assistant to your site so you can safely edit, inspect, and manage content using natural language. It provides a controlled workflow that keeps your live site protected while enabling fast, precise changes through tools like [Cursor](https://cursor.com), [Claude Code](https://claude.ai), and [Windsurf](https://codeium.com/windsurf).
 
-Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow and expose 260 MCP tools plus 228 WebMCP abilities depending on your add-ons and runtime.
+Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow and expose 261 MCP tools plus 229 WebMCP abilities depending on your add-ons and runtime.
 
 ## What is Respira for WordPress?
 

--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -5,7 +5,7 @@ description: "Reference for current Respira MCP tools. Find the right tool for p
 
 # Tools Reference
 
-Respira provides 260 MCP tools for AI assistants to interact with WordPress (173 in every core plan, plus 87 in the WooCommerce add-on), alongside 228 WebMCP browser abilities. This reference documents the core categories and naming patterns.
+Respira provides 261 MCP tools for AI assistants to interact with WordPress (174 in every core plan, plus 87 in the WooCommerce add-on), alongside 229 WebMCP browser abilities. This reference documents the core categories and naming patterns.
 
 ## Tool Categories
 
@@ -68,7 +68,7 @@ Read-only analysis of SEO, performance, images, and AI Engine Optimization (AEO)
 - [wordpress_analyze_aeo](/tools/analysis/analyze-aeo)
 - [wordpress_check_structured_data](/tools/analysis/check-structured-data)
 
-### Menu Tools (12 tools)
+### Menu Tools (13 tools)
 
 Manage WordPress navigation menus and menu items.
 
@@ -84,6 +84,7 @@ Manage WordPress navigation menus and menu items.
 - [wordpress_get_menu_item](/tools/menus/get-menu-item)
 - [wordpress_update_menu_item](/tools/menus/update-menu-item)
 - [wordpress_delete_menu_item](/tools/menus/delete-menu-item)
+- `wordpress_build_mega_menu` <span style={{color: '#10b981'}}>NEW in 7.6.1</span> — builds a complete Divi mega menu in one call (a top item with the `mega-menu` class, columns as children, links as grandchildren) and can assign it to a theme location. Works on Divi 4 and Divi 5.
 
 ### Media Tools (5 tools)
 
@@ -229,7 +230,7 @@ Create and update WPML translations through the agent. A created translation joi
 | Builders | 3 | 1 | 2 |
 | Fidelity & Snapshots | 5 | 3 | 2 |
 | Analysis | 9 | 9 | 0 |
-| Menus | 12 | 4 | 8 |
+| Menus | 13 | 4 | 9 |
 | Media | 5 | 2 | 3 |
 | Users | 5 | 2 | 3 |
 | Taxonomies | 7 | 4 | 3 |
@@ -249,9 +250,9 @@ Create and update WPML translations through the agent. A created translation joi
 | Theme Builder — Divi <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
 | Translations — WPML <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
 | WooCommerce (add-on) | 21 | 11 | 10 |
-| **Total** | **240** | **98** | **142** |
+| **Total** | **241** | **98** | **143** |
 
-> This table lists the documented core categories. The full MCP surface is **260 tools** (173 in core plans plus 87 in the WooCommerce add-on) alongside **228 WebMCP browser abilities** — see the live counts on [respira.press](https://respira.press).
+> This table lists the documented core categories. The full MCP surface is **261 tools** (174 in core plans plus 87 in the WooCommerce add-on) alongside **229 WebMCP browser abilities** — see the live counts on [respira.press](https://respira.press).
 
 ## Tool Naming Convention
 


### PR DESCRIPTION
Adds wordpress_build_mega_menu to the tools reference and bumps counts to 261 tools / 229 abilities. Divi 4 + Divi 5.