### PR TITLE
docs(8.0): Canopy release, the native Site Editor

### DIFF
--- a/arc.mdx
+++ b/arc.mdx
@@ -32,7 +32,7 @@ After activation you get a screen under WooCommerce called Respira ARC:
 
 ## ARC and the WooCommerce Add-on
 
-ARC is the readable half. The paid [WooCommerce Add-on](/woocommerce/overview) contains all of ARC plus the agent that acts on what ARC finds: 87 tools that can fix every product failing the feed checks, write descriptions and alt text, assign brands and GTINs, manage orders and refunds, and edit STAGGS configurators, each write behind a snapshot with 90-day rollback.
+ARC is the readable half. The paid [WooCommerce Add-on](/woocommerce/overview) contains all of ARC plus the agent that acts on what ARC finds: 105 tools that can fix every product failing the feed checks, write descriptions and alt text, assign brands and GTINs, manage orders and refunds, and edit STAGGS configurators, each write behind a snapshot with 90-day rollback.
 
 You never need both installed. If the add-on is present, ARC steps aside automatically and your settings carry over. Full detail on the paid layer: [Agent-Ready Commerce](/woocommerce/agent-ready-commerce).
 

--- a/browser-ai.mdx
+++ b/browser-ai.mdx
@@ -44,9 +44,9 @@ If you get results, Browser AI is ready.
 
 Browser AI has access to a comparable toolset to desktop mode:
 
-- 100+ tools total (with add-ons)
+- 269 WebMCP abilities in the browser
 - Browser inventory follows the active plugin release contract
-- Desktop MCP currently exposes `82` WordPress tools + `21` WooCommerce tools
+- Desktop MCP currently exposes `197` tools on any WordPress site, and `302` with the WooCommerce add-on (`105` of those are `woocommerce_*` tools)
 - Same duplicate-before-edit safety workflow
 
 ## Browser AI vs Angie vs the official adapter

--- a/builders/divi.mdx
+++ b/builders/divi.mdx
@@ -119,11 +119,39 @@ Respira detects Divi Global Modules. Updates to global modules appear everywhere
 - "List all global modules" → Shows global module library
 - "Update the global footer email address" → Changes it site-wide
 
+## Theme Builder: the live-edit confirmation handshake
+
+Divi Theme Builder global layouts (global headers, global footers, global bodies) are **written live**, not staged.
+
+They cannot be staged the way a page can. Divi resolves a global layout by id, so a staged duplicate would compete with the original instead of sitting quietly next to it. That is a property of how Divi works, and pretending otherwise would be worse than saying it plainly.
+
+What 8.0 adds instead is a confirmation handshake:
+
+- The **first** attempt to rewrite a global header, footer or body is **refused** with `respira_tb_live_edit_confirmation_required`.
+- The refusal names the layout and states that the change affects every page using it.
+- To proceed, re-send the same call with `confirm_live_edit=true`.
+
+<Callout kind="alert">
+
+This is a **confirmation, not an approval.** Approval means a human reviews a staged change before it exists on the live site. Confirmation means the agent is told what it is about to touch, and has to say yes on purpose. A Theme Builder global layout write goes live when confirmed.
+
+</Callout>
+
+Global layout writes are still snapshotted and reversible. If a confirmed write lands wrong, restore the snapshot from the Changes page in WordPress admin.
+
 ## Limitations
 
 - Visual-only settings (hover states) may need Divi builder
 - Per-module custom CSS is supported but complex styling may need builder
 - Dynamic content tokens are preserved but not directly editable
+- Theme Builder global layouts are written live behind a confirmation handshake, not staged for approval
+
+## Recent capabilities (8.0 "Canopy")
+
+Two fixes from auditing the safety layer itself, both on the Divi path:
+
+- **A Divi 4 serializer rule stopped firing where it did not belong.** The rule was written for brand-new pages, but it ran on every write path, which meant it retyped existing Code modules on pages it should only have passed through.
+- **Undoing a Theme Builder create no longer trashes a template the agent never created.** The undo path could reach past its own work.
 
 ## Recent capabilities (plugin v7.5.x)
 

--- a/builders/gutenberg.mdx
+++ b/builders/gutenberg.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Gutenberg (Block Editor) Reference"
-description: "Technical documentation for using Respira with Gutenberg: WordPress block editing, content updates, and SEO workflows."
+description: "Technical documentation for using Respira with Gutenberg: WordPress block editing, block templates and template parts, synced patterns, block navigation, global styles, content updates, and SEO workflows."
 ---
 
 # Gutenberg (Block Editor) Reference
@@ -10,6 +10,12 @@ Technical documentation for using Respira with the [WordPress Block Editor](http
 ## About Gutenberg
 
 The [WordPress Block Editor](https://wordpress.org/gutenberg/), commonly known as Gutenberg, is WordPress's default content editor since version 5.0. It powers over 40% of all websites on the internet through WordPress core.
+
+<Callout kind="info">
+
+This page covers block-level editing inside a page or post. For the site-level surface, block templates and template parts, synced and unsynced patterns, block navigation and global styles, see [Site Editor (Full Site Editing)](/builders/site-editor), new in Respira 8.0 "Canopy".
+
+</Callout>
 
 ## Prompting for great results on Gutenberg
 
@@ -107,22 +113,40 @@ Set in Block Settings → Advanced → HTML Anchor:
 - "Update the copyright text in the footer on all pages"
 - "Add alt text to all images missing it"
 
-## Reusable Blocks
+## Patterns (formerly Reusable Blocks)
 
-Gutenberg Reusable Blocks (now called Patterns) can be updated through Respira:
+Patterns are addressable through Respira, including their synced or unsynced state:
 
-- "List all reusable blocks" → Shows pattern library
-- "Update the reusable CTA block button text" → Changes it everywhere used
+- Registered theme and plugin patterns are read-only. They live in theme or plugin code, not in the database.
+- Editable user patterns (`wp_block`) can be created, read, updated and deleted, and a synced pattern changes everywhere it is used.
+
+- "List the synced patterns on this site" → shows the editable pattern library with its synced state
+- "Update the CTA pattern button text" → changes it everywhere the synced pattern is used
+
+Full detail, including the safety contract that applies because a synced pattern is a shared object, is on the [Site Editor](/builders/site-editor) page.
 
 ## Full Site Editing (FSE)
 
-For themes using Full Site Editing, Respira can access template parts:
+Respira 8.0 "Canopy" makes the native WordPress Site Editor a first-class target rather than a partial read. On a block theme, these are addressable:
 
-- Header and footer templates
-- Post and page templates
-- Archive templates
+- **Block templates and template parts** (`wp_template`, `wp_template_part`) with template hierarchy and source discovery, so you know whether a template is theme-provided, plugin-provided or a database customisation
+- **Synced and unsynced patterns** (`wp_block`), with registered theme and plugin patterns kept read-only
+- **Block navigation** (`wp_navigation`), edited by exact block path rather than by rewriting the navigation document. A guessed path is refused, and a stale revision is refused
+- **Gutenberg design tokens and global styles**, so colours, typography and spacing change at the source
 
-Example: "Update the site header tagline to 'Your Success Partner'"
+Every structural write is fingerprint-guarded against a stale base, snapshotted, read back through WordPress, and server-render verified. It reports `verified` only after WordPress has actually rendered it. A write can also be staged as a proposal for human approval instead of applied.
+
+<Callout kind="alert">
+
+**Structural writes to site-level objects are beta-gated per site and OFF by default.** Read-only discovery of templates, patterns, navigation and global styles works everywhere. Structural writes have to be enabled for the specific site.
+
+</Callout>
+
+Example: "Show me the header template part and the navigation inside it, and do not change anything."
+
+The FSE work exists because of a published field study by [Dale Smith of revWorx](https://revworx.ai/), who builds exclusively on FSE block themes and documented, live-verified, where Respira went inert on that stack.
+
+See [Site Editor (Full Site Editing)](/builders/site-editor) for the tools, the mutation-result contract, and the beta gate.
 
 ## Best Use Cases
 
@@ -131,16 +155,21 @@ Example: "Update the site header tagline to 'Your Success Partner'"
 - **SEO and readability workflows** - Batch-fix heading hierarchy or missing alt text
 - **Programmatic content** - Update dates, years, or repeated content across pages
 
+## Recent capabilities (8.0 "Canopy")
+
+- **The Site Editor is a first-class target.** Block templates, template parts, synced and unsynced patterns, block navigation and global styles are addressable, with structural writes behind a fingerprint, a snapshot, a read-back and a server-render check. See [Site Editor](/builders/site-editor).
+- **Navigation is edited by block path.** A menu link changes without re-serialising the whole navigation document, and a guessed path or a stale revision is refused instead of applied.
+
 ## Recent capabilities (7.4.x)
 
 - **`build_page` no longer emits a non-existent `core/section` block.** A `section` type used to fall through to `core/section`, which WordPress renders as "This block is not supported" and the front end drops; `row` had the same gap. `section`/`container`/`wrapper` now map to `core/group` and `row` to `core/columns`, so a full-page build is valid, nested and renders. Native block support is otherwise full: Respira reads every registered block from the block registry, core and third-party alike.
 
 ## Limitations
 
-- **Block patterns**: Pattern structure is preserved, but pattern-specific styling may need the editor
+- **Registered theme and plugin patterns are read-only**: they live in code, not the database. Copy one into a user pattern to change it
 - **Third-party blocks**: Respira reads all registered blocks dynamically from the block registry, including core and third-party blocks
 - **Interactive blocks**: Blocks with complex interactivity (forms, carousels) may need manual editing
-- **Theme-specific blocks**: Full Site Editing theme blocks work, but custom themes may vary
+- **Site-level structural writes are beta-gated per site and off by default**: read-only discovery of templates, patterns, navigation and global styles is available everywhere
 
 ## When to Use This Tool
 
@@ -155,4 +184,5 @@ Example: "Update the site header tagline to 'Your Success Partner'"
 - [wordpress_update_page](/tools/pages/update-page) - Update page content
 - [wordpress_analyze_seo](/tools/analysis/analyze-seo) - Analyze page SEO
 - [wordpress_analyze_readability](/tools/analysis/analyze-readability) - Check content readability
+- [Site Editor (Full Site Editing)](/builders/site-editor) - Templates, patterns, navigation, global styles
 - [Page Builder Overview](/builders/overview) - Compare all supported builders

--- a/builders/overview.mdx
+++ b/builders/overview.mdx
@@ -1,11 +1,13 @@
 ---
 title: "Page Builder Support"
-description: "How Respira edits 16 WordPress page builders at the module level. Update buttons, text, and sections without breaking layouts."
+description: "How Respira edits 16 WordPress page builders plus the native Site Editor at the module level. Update buttons, text, and sections without breaking layouts."
 ---
 
 # Page Builder Support
 
-Respira understands 16 WordPress page builders at the module level. AI can update specific sections, buttons, or text blocks without affecting the rest of your page.
+Respira understands 16 WordPress page builders at the module level, plus the native Site Editor. AI can update specific sections, buttons, or text blocks without affecting the rest of your page.
+
+As of 8.0 "Canopy" the coverage line is **16 page builders plus the native Site Editor**.
 
 ## Supported Builders
 
@@ -28,7 +30,19 @@ Respira understands 16 WordPress page builders at the module level. AI can updat
 | [GenerateBlocks](/builders/generateblocks) | Blocks | Blocks | ✓ Full |
 | [SeedProd](/builders/seedprod) | Blocks | Blocks | Audit only |
 
-> Divi covers Divi 4 and Divi 5; Oxygen covers Oxygen Classic and Oxygen 6. With those variants, that is **16 builders** with full read and write. SeedProd is audit-only (agents read and report on landing pages). Brizy and Visual Composer moved from read to write in Respira 7.4.0 "Clearing".
+Plus the native WordPress Site Editor:
+
+| Target | Objects | Data Format | Editing |
+|--------|---------|-------------|---------|
+| [Site Editor (FSE)](/builders/site-editor) | Templates, template parts, patterns, navigation, global styles | Block markup / `theme.json` | Read everywhere. Structural writes beta-gated per site |
+
+> Divi covers Divi 4 and Divi 5; Oxygen covers Oxygen Classic and Oxygen 6. With those variants, that is **16 builders** with full read and write. SeedProd is audit-only (agents read and report on landing pages). Brizy and Visual Composer moved from read to write in Respira 7.4.0 "Clearing". The native Site Editor became a first-class target in Respira 8.0 "Canopy" and is counted separately from the 16 builders.
+
+### New in 8.0 "Canopy": the native Site Editor
+
+Block themes used to be a partial read. In 8.0 the Site Editor is addressable: block templates and template parts with hierarchy and source discovery, synced and unsynced patterns, block navigation edited by exact block path, and Gutenberg design tokens.
+
+Structural writes to those site-level objects are beta-gated per site and off by default. Read-only discovery works everywhere. See [Site Editor (Full Site Editing)](/builders/site-editor).
 
 ### New in v6.0: Flatsome UX Builder
 
@@ -78,7 +92,7 @@ AI: Uses respira_update_element → Updates just that text
 
 ## Context-Aware Tool Filtering
 
-As of v6.0, the MCP server automatically filters the tool list based on your site's detected builder. A Divi site without WooCommerce sees ~130 tools instead of ~170. Less noise, faster AI responses.
+The MCP server filters the tool list based on your site's detected builder, so a site only sees the tools that apply to it. The measured surface as of 8.0 is 197 tools on any WordPress site and 302 with the WooCommerce add-on installed. Builder-specific tools (for example the Bricks and Elementor deep tools) only register when that builder is present. Less noise, faster AI responses.
 
 ## Best Practice: Use Admin Labels
 
@@ -94,7 +108,7 @@ Then: "Update the module labeled 'Hero CTA Button' to say 'Contact Us'"
 
 ### Which page builder has the best Respira support?
 
-All 16 supported builders have full module-level editing support. Divi and Elementor have the most comprehensive intelligence packages. Bricks has 20 dedicated deep tools. Flatsome has a 55-element intelligence package with nesting rules and page patterns.
+All 16 supported builders have full module-level editing support. Divi and Elementor have the most comprehensive intelligence packages. Bricks has 20 dedicated deep tools. Flatsome has a 55-element intelligence package with nesting rules and page patterns. The native Site Editor is covered separately on the [Site Editor](/builders/site-editor) page.
 
 ### Can Respira edit Global Modules in Divi?
 

--- a/builders/site-editor.mdx
+++ b/builders/site-editor.mdx
@@ -1,0 +1,152 @@
+---
+title: "Site Editor (Full Site Editing)"
+description: "How Respira reads and writes the native WordPress Site Editor: block templates and template parts, synced and unsynced patterns, block navigation, and global styles, with the fingerprint and read-back safety contract."
+---
+
+# Site Editor (Full Site Editing)
+
+Respira 8.0 "Canopy" makes the native WordPress Site Editor a first-class target. Before 8.0, a block theme was a blind spot: Respira could read and write a page's blocks, but the things that actually define a block theme site, the templates, the template parts, the patterns, the navigation and the global styles, were not addressable.
+
+That gap is closed. The positioning line for 8.0 is **16 page builders plus the native Site Editor**.
+
+<Callout kind="info">
+
+The FSE work exists because of a published field study by [Dale Smith of revWorx](https://revworx.ai/), who builds exclusively on FSE block themes and documented, live-verified, that Respira's storefront tools went inert on that stack. The study named the gap precisely enough to fix.
+
+</Callout>
+
+## What is addressable
+
+### Block templates and template parts
+
+`wp_template` and `wp_template_part` are readable and writable, with template hierarchy and source discovery. Source discovery matters on a block theme: a template can come from the theme's files, from a plugin, or from the database once a user has customised it, and the three behave differently. Respira reports which one you are looking at instead of guessing.
+
+- `respira_list_site_templates`, `respira_get_site_template`
+- `respira_create_site_template`, `respira_update_site_template`, `respira_reset_site_template`
+
+Resetting a customised template returns it to the theme-provided version, which is the Site Editor's own "clear customisations" behaviour.
+
+### Synced and unsynced patterns
+
+Patterns (`wp_block`) are readable and writable, including their synced or unsynced state.
+
+- Registered theme and plugin patterns stay **read-only**. They live in code, not in the database, and Respira will not pretend otherwise.
+- Editable user patterns support the synced/unsynced distinction. A synced pattern changes every place it is used. An unsynced pattern is a starting point that gets copied.
+
+- `respira_list_site_patterns`, `respira_get_site_pattern`
+- `respira_create_site_pattern`, `respira_update_site_pattern`, `respira_delete_site_pattern`
+
+### Block navigation
+
+Block navigation (`wp_navigation`) is edited **by exact block path**, not by rewriting the navigation document. This is the difference between changing one link and re-serialising a menu.
+
+Two refusals protect that:
+
+- A **guessed path is refused.** If the path does not resolve to a block that is actually there, the write does not happen.
+- A **stale revision is refused.** If the navigation changed since the agent read it, the write does not happen.
+
+- `respira_list_site_navigations`, `respira_get_site_navigation`
+- `respira_create_site_navigation`, `respira_update_site_navigation`, `respira_delete_site_navigation`
+
+### Global styles and design tokens
+
+Gutenberg design tokens and global styles (the `theme.json` layer as WordPress resolves it at runtime) are readable and writable, so colours, typography and spacing can be changed at the source rather than patched per block.
+
+- `respira_list_design_tokens`
+- `respira_create_design_token`, `respira_update_design_token`, `respira_delete_design_token`
+
+## The safety contract for structural writes
+
+A page is one document. A template, a template part, a synced pattern and a navigation are shared objects: one write reaches every page that uses them. Structural writes are held to a stricter contract because of that.
+
+Every structural write is:
+
+1. **Fingerprint-guarded against a stale base.** The agent's read is fingerprinted. If the object moved underneath it, the write is refused rather than applied on top of someone else's change.
+2. **Snapshotted** before the change, so it is reversible.
+3. **Read back through WordPress** after the change, rather than trusting the write call's return value.
+4. **Server-render verified.** The result is only reported as `verified` once WordPress has actually rendered it.
+
+### Mutation-result contract
+
+Every structural mutation returns one of these, and they mean different things:
+
+| Result | Meaning |
+|--------|---------|
+| `dry_run` | Nothing was written. This is the preview of what would change. |
+| `pending_approval` | The change was staged as a proposal. A human approves it before it applies. |
+| `verified` | Written, read back through WordPress, and confirmed rendered. |
+| `stored_unverified` | Written and stored, but the render check did not confirm it. Treat as needing a look. |
+| `no_match` | The target did not resolve. Nothing was written. |
+| failure | The write did not happen, with the reason. |
+
+<Callout kind="tip">
+
+`stored_unverified` is not a success. It is Respira declining to claim more than it can prove. If you see it, open the object in the Site Editor and check.
+
+</Callout>
+
+### Structural proposals
+
+A structural write can be **staged for human approval instead of applied**. The write returns `pending_approval`, the proposed change waits, and a person decides. This is the site-level equivalent of duplicate-before-edit: the agent does the work, you keep the last move.
+
+### Activity history
+
+8.0 adds an agent-facing activity history that links audit entries to the snapshots, proposals, approvals and rollbacks they belong to, so the trail of a change is one query rather than a reconstruction.
+
+- `respira_list_activity`, `respira_get_activity`
+
+## Beta gate: structural writes are off by default
+
+<Callout kind="alert">
+
+**Structural writes to site-level objects (templates, template parts, patterns, navigation, global styles) are beta-gated per site and OFF by default.**
+
+Read-only discovery works everywhere with no gate. If you want structural writes on a given site, they have to be turned on for that site.
+
+</Callout>
+
+This is deliberate. A bad page edit costs you one page. A bad template edit costs you every page that uses the template. The gate stays on until the write path has more live mileage.
+
+## What to ask for
+
+Read-only, available on any site with a block theme:
+
+```text
+List the block templates on this site and tell me which ones
+are theme-provided and which ones have been customised.
+```
+
+```text
+Show me the header template part and the navigation inside it.
+Do not change anything.
+```
+
+```text
+List the synced patterns on this site and tell me which pages use them.
+```
+
+With structural writes enabled on the site:
+
+```text
+Change the third link in the primary navigation to point to /pricing.
+Edit it by block path, do not rewrite the whole menu. Show me a dry run first.
+```
+
+```text
+Stage a change to the footer template part that adds the new address block.
+I want to approve it before it goes live.
+```
+
+## Limits worth knowing
+
+- Registered theme and plugin patterns cannot be edited. They are code. Copy one into a user pattern if you want to change it.
+- A navigation write needs a real block path. Asking an agent to "fix the menu" without reading it first will get a refusal, not a guess.
+- `stored_unverified` means the render check did not confirm. Check it by hand.
+- The beta gate is per site. Turning it on for one site does not turn it on for the rest.
+
+## See also
+
+- [Gutenberg (Block Editor) Reference](/builders/gutenberg) for block-level page editing
+- [Safety Philosophy](/safety-philosophy) for the duplicate-before-edit workflow
+- [Page Builder Support](/builders/overview) for the full builder matrix
+- [WooCommerce Add-on](/woocommerce/overview) for FSE-first storefront analysis

--- a/changelog.mdx
+++ b/changelog.mdx
@@ -52,6 +52,45 @@ Not a WP-CLI replacement. WP-CLI is excellent for server-side WordPress administ
 
 ## WordPress Plugin Releases
 
+<Update label="2026-07-26" description="Respira for WordPress v8.0.0 'Canopy' + MCP Server v8.0.0 + WooCommerce Add-on v4.0.0: the native Site Editor" tags={["release", "gutenberg", "fse", "site-editor", "safety"]}>
+
+### What's New in v8.0.0 "Canopy"
+
+Respira has always been strong on page builders and thin on the thing WordPress core is actually pushing people toward. 8.0 closes that. The coverage line is now **16 page builders plus the native Site Editor**.
+
+Measured on a live install: **197 tools** on any WordPress site, **302** with the WooCommerce add-on (of which **105** are `woocommerce_*` tools), **269** WebMCP abilities, **37** skills.
+
+**The native WordPress Site Editor is a first-class target**
+- Block templates and template parts (`wp_template`, `wp_template_part`) with template hierarchy and source discovery, so you know whether a template is theme-provided, plugin-provided, or a database customisation
+- Synced and unsynced patterns (`wp_block`). Registered theme and plugin patterns stay read-only. Editable user patterns support the synced/unsynced distinction
+- Block navigation (`wp_navigation`) edited by exact block path, not by rewriting the navigation document. A guessed path is refused. A stale revision is refused
+- Gutenberg design tokens and global styles
+
+**The safety contract for structural writes**
+- Every structural write is fingerprint-guarded against a stale base, snapshotted, read back through WordPress, and server-render verified. It returns `verified` only after WordPress actually rendered it
+- Structural proposals: a write can be staged for human approval instead of applied
+- The mutation-result contract is explicit: `dry_run`, `pending_approval`, `verified`, `stored_unverified`, `no_match`, or a failure with a reason
+- An agent-facing activity history links audit entries to snapshots, proposals, approvals, and rollbacks
+
+**Structural writes are beta-gated**
+- Structural writes to site-level objects are beta-gated per site and OFF by default. Read-only discovery works everywhere. The gate stays until that write path has more live mileage
+
+**Two safety fixes found by auditing the safety layer itself**
+- A Divi 4 serializer rule written for brand-new pages was firing on every write path, retyping existing Code modules on pages it should only have passed through
+- Undoing a Theme Builder create could trash a template the agent never created
+
+**Divi Theme Builder: a confirmation handshake, not an approval**
+- Divi Theme Builder global layouts are snapshotted and reversible but written live, not staged. They cannot be staged the way a page can, because Divi resolves a global layout by id and a duplicate would compete with the original
+- The first attempt to rewrite a global header, footer, or body is now refused with `respira_tb_live_edit_confirmation_required`, naming the layout and saying it changes every page using it. Re-send with `confirm_live_edit=true` to proceed
+- That is a confirmation, not an approval. A confirmed write goes live
+
+**Credit**
+- The FSE work was driven by a published field study from Dale Smith of [revWorx](https://revworx.ai/), who builds exclusively on FSE block themes and documented, live-verified, that Respira's storefront tools went inert on that stack
+
+Documentation: [Site Editor (Full Site Editing)](/builders/site-editor).
+
+</Update>
+
 <Update label="2026-07" description="Respira for WordPress v7.5.x — ChatGPT connector + server-truth connectivity (latest v7.5.18)" tags={["release", "oauth", "chatgpt", "connectivity"]}>
 
 ### What's New in the 7.5.x line
@@ -491,6 +530,37 @@ Download: [respira-for-wordpress-1.9.1.zip](https://respira.press/releases)
 
 ## WooCommerce Add-on Releases
 
+<Update label="2026-07-26" description="WooCommerce Add-on v4.0.0: FSE-first storefront, reporting, webhooks" tags={["feature", "woocommerce", "fse", "reporting", "webhooks"]}>
+
+### WooCommerce Add-on v4.0.0
+
+The storefront layer stops assuming a page builder. 105 tools total. Requires Respira for WordPress plugin 8.0.0 or newer.
+
+**Storefront intelligence is FSE-first with page-builder fallback**
+- On a block theme, analysing a shop page returns real structural analysis against the native `archive-product` template instead of "no page builder detected". Where a page builder is present, the builder path still runs
+
+**Badges match WooCommerce's own product card**
+- Sale and low-stock badges are positioned inside the product image, where WooCommerce puts them
+- An existing badge means the write is refused as a no-op rather than duplicated, so re-running a prompt does not stack badges
+
+**Product-card fields addressed by canonical block name**
+- `woocommerce/product-image`, `woocommerce/product-price`, `woocommerce/product-title`, `woocommerce/product-button`
+- Requested attributes are intersected with the installed block's registered attributes, so an unrecognised key is refused rather than silently accepted
+
+**Reporting**
+- Bounded, HPOS-compatible revenue reporting, sales time-series, top products, orders, and privacy-safe customer reporting
+
+**Read-only store discovery**
+- Store configuration, payment gateways, shipping zones, and tax rates
+
+**Approval-gated native webhooks**
+- HTTPS targets only, allowlisted topics only, write-only secrets, and a human approval on every webhook change
+
+**Credit**
+- The FSE gap was found and published by Dale Smith of [revWorx](https://revworx.ai/), who builds exclusively on FSE block themes and verified live that the storefront tools were inert there
+
+</Update>
+
 <Update label="2026-07-17" description="WooCommerce Add-on v3.2.0: STAGGS configurator suite" tags={["feature", "woocommerce", "configurators"]}>
 
 ### WooCommerce Add-on v3.2.0
@@ -534,9 +604,32 @@ Complete WooCommerce agent coverage: 56 tools.
 
 ## MCP Server Releases
 
-<Update label="2026-03-07" description="MCP Server v3.3.5" tags={["improvement", "telemetry"]}>
+<Update label="2026-07-26" description="MCP Server v8.0.0 'Canopy': Site Editor tools and the mutation-result contract" tags={["release", "mcp", "fse", "site-editor"]}>
 
 ### Latest MCP server version
+
+The current MCP server release is **v8.0.0**, shipped alongside plugin v8.0.0 and WooCommerce add-on v4.0.0.
+
+Install: `npx @respira/wordpress-mcp-server`
+
+npm: [@respira/wordpress-mcp-server](https://www.npmjs.com/package/@respira/wordpress-mcp-server)
+
+### What's New
+
+Measured by booting the server and calling `tools/list`: **197 tools** on any WordPress site, **302** with the WooCommerce add-on active (**105** of those are `woocommerce_*` tools), alongside **269** WebMCP abilities and **37** skills.
+
+- Site Editor tools: block templates and template parts, synced and unsynced patterns, block navigation, and design tokens
+- Navigation is edited by exact block path. A guessed path is refused, and a stale revision is refused
+- Every structural mutation returns one of `dry_run`, `pending_approval`, `verified`, `stored_unverified`, `no_match`, or a failure with a reason. `verified` is only returned after WordPress rendered the result
+- Structural writes to site-level objects are beta-gated per site and off by default. Read-only discovery is available everywhere
+- Activity tools that link audit entries to snapshots, proposals, approvals, and rollbacks
+- Divi Theme Builder global layout writes require the `confirm_live_edit=true` handshake after the first refusal with `respira_tb_live_edit_confirmation_required`
+
+</Update>
+
+<Update label="2026-03-07" description="MCP Server v3.3.5" tags={["improvement", "telemetry"]}>
+
+### MCP server v3.3.5
 
 Install: `npx @respira/wordpress-mcp-server`
 

--- a/documentation.json
+++ b/documentation.json
@@ -899,6 +899,11 @@
                 "icon": "layout"
               },
               {
+                "title": "Site Editor (FSE)",
+                "path": "builders/site-editor",
+                "icon": "layout"
+              },
+              {
                 "title": "WPBakery",
                 "path": "builders/wpbakery",
                 "icon": "layout"

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -7,7 +7,7 @@ description: Quick start guide for connecting Respira for WordPress to AI coding
 
 Respira for WordPress connects your AI coding assistant to your site so you can safely edit, inspect, and manage content using natural language. It provides a controlled workflow that keeps your live site protected while enabling fast, precise changes through tools like [Cursor](https://cursor.com), [Claude Code](https://claude.ai), and [Windsurf](https://codeium.com/windsurf).
 
-Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow and expose 261 MCP tools plus 229 WebMCP abilities depending on your add-ons and runtime.
+Respira now supports two workflows: **Browser AI** (WebMCP built-in) and **Desktop AI** (MCP server). Both share the same safety workflow. As of 8.0 "Canopy" that is 197 MCP tools on any WordPress site, 302 with the WooCommerce add-on, plus 269 WebMCP abilities, depending on your add-ons and runtime.
 
 ## What is Respira for WordPress?
 
@@ -15,8 +15,9 @@ Respira is a safe bridge between your AI coding assistant and WordPress. It tran
 
 - Safely lets [Claude Cowork](https://respira.press/cowork), [Cursor](https://cursor.com), [Claude Code](https://claude.ai), [Windsurf](https://codeium.com/windsurf), and other AI coding assistants edit WordPress
 - Uses a duplicate-first workflow so AI edits copies; you approve before anything goes live
-- Understands 16 page builders, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd
-- 254 MCP tools including ACF, WooCommerce (87 tools via the add-on), element-level editing, page building, stock images, and tool governance
+- Understands 16 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd, plus [block templates, patterns, navigation and global styles](/builders/site-editor)
+- 197 MCP tools on any WordPress site, 302 with the WooCommerce add-on (105 `woocommerce_*` tools), covering ACF, the Site Editor, element-level editing, page building, stock images, and tool governance
+- 269 WebMCP abilities and 37 skills
 - Requires no SSH or complex hosting setup—works on typical shared hosting
 
 ### Who this guide is for
@@ -162,6 +163,7 @@ You have successfully connected your AI coding assistant to WordPress.
 - [Usage Guide](/usage)
 - [Tools Reference](/tools/overview) - Tool categories, naming, and usage guidance
 - [Page Builder Support](/builders/overview) - How Respira works with 16 builders
+- [Site Editor (Full Site Editing)](/builders/site-editor) - Templates, patterns, navigation, global styles
 - [Prompts & Examples](/prompts)
 - [Troubleshooting](/troubleshooting)
 
@@ -211,4 +213,4 @@ Yes. Respira offers a free trial. You can start without entering payment details
 
 ### Which page builders does Respira support?
 
-Respira supports 16 page builders, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd. See [Page Builder Support](/builders/overview) for the full matrix.
+Respira supports 16 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd. Since 8.0 "Canopy", block themes are covered at the site level too: templates, patterns, navigation and global styles. See [Page Builder Support](/builders/overview) for the full matrix and [Site Editor](/builders/site-editor) for the FSE surface.

--- a/safety-philosophy.mdx
+++ b/safety-philosophy.mdx
@@ -53,6 +53,46 @@ If you know how to review drafts in WordPress, you already know how to review Re
 >
 > — danieliser, Anthropic engineer
 
+## Structural writes: a stricter contract (8.0 "Canopy")
+
+Duplicate-before-edit works because a page is one document. A block template, a template part, a synced pattern, a navigation, or a set of global styles is a shared object: one write reaches every page that uses it, and there is nothing sensible to duplicate. Those writes get their own contract instead.
+
+Every structural write is:
+
+1. **Fingerprint-guarded against a stale base.** The agent's read is fingerprinted. If the object changed underneath it, the write is refused rather than applied over someone else's work.
+2. **Snapshotted** before the change, so it is reversible.
+3. **Read back through WordPress** afterwards, instead of trusting the write call's own return value.
+4. **Server-render verified.** The result is reported as `verified` only once WordPress has actually rendered it.
+
+A structural write can also be **staged as a proposal** for a human to approve rather than applied. That is the site-level equivalent of the duplicate: the agent does the work, you keep the last move.
+
+### What a mutation can tell you
+
+| Result | Meaning |
+|--------|---------|
+| `dry_run` | Nothing was written. A preview of what would change. |
+| `pending_approval` | Staged as a proposal. A human approves before it applies. |
+| `verified` | Written, read back, and confirmed rendered by WordPress. |
+| `stored_unverified` | Written, but the render check did not confirm it. Go look. |
+| `no_match` | The target did not resolve. Nothing was written. |
+| failure | The write did not happen, with the reason. |
+
+<Callout kind="alert">
+
+**Structural writes to site-level objects are beta-gated per site and OFF by default.** Read-only discovery of templates, patterns, navigation, and global styles works everywhere. A bad page edit costs one page. A bad template edit costs every page that uses it, which is why the gate exists. See [Site Editor](/builders/site-editor).
+
+</Callout>
+
+An agent-facing activity history links audit entries to the snapshots, proposals, approvals, and rollbacks they belong to, so the trail of a change is one query rather than a reconstruction.
+
+### Confirmation is not approval
+
+One case does not fit the staging model, and it is documented rather than hidden. Divi Theme Builder global layouts are written **live**. They cannot be staged the way a page can, because Divi resolves a global layout by id and a staged duplicate would compete with the original.
+
+What 8.0 adds there is a confirmation handshake: the first attempt to rewrite a global header, footer, or body is refused with `respira_tb_live_edit_confirmation_required`, naming the layout and stating that it changes every page using it. Re-sending with `confirm_live_edit=true` proceeds.
+
+That is a confirmation, not an approval. Approval means a human reviews a staged change before it exists on the live site. Confirmation means the agent is told what it is about to touch and has to say yes on purpose. The write is still snapshotted and reversible. See [Divi](/builders/divi).
+
 ## How this compares to other safety strategies
 
 Many teams already use safety strategies like staging sites, git-based rollbacks, or careful admin-side editing. Respira’s approach is different: it builds safety into each AI operation instead of relying on environment-level safeguards.

--- a/support/faq.mdx
+++ b/support/faq.mdx
@@ -33,6 +33,8 @@ Yes. Respira offers a free trial. You can start without entering payment details
 
 Respira supports 16 page builders with full read and write: Gutenberg, Elementor, Divi 4, Divi 5, Bricks, Oxygen Classic, Oxygen 6, Beaver Builder, Breakdance, Flatsome, Brizy, Visual Composer, WPBakery, Spectra, Kadence Blocks, and GenerateBlocks. SeedProd is audit-only (agents read and report on landing pages), and Thrive Architect supports text edits.
 
+Since 8.0 "Canopy" the native WordPress Site Editor is covered too, which makes the line "16 page builders plus the native Site Editor". On a block theme that means block templates and template parts, synced and unsynced patterns, block navigation, and global styles. Read-only discovery works everywhere; structural writes to those site-level objects are beta-gated per site and off by default. See [Site Editor](/builders/site-editor).
+
 ## I see `respira_mcp_update` in responses. Is that an error?
 
 No. It is an upgrade hint from the MCP server when a newer package version is available. Upgrade with:

--- a/tools/overview.mdx
+++ b/tools/overview.mdx
@@ -5,7 +5,7 @@ description: "Reference for current Respira MCP tools. Find the right tool for p
 
 # Tools Reference
 
-Respira provides 261 MCP tools for AI assistants to interact with WordPress (174 in every core plan, plus 87 in the WooCommerce add-on), alongside 229 WebMCP browser abilities. This reference documents the core categories and naming patterns.
+As of 8.0 "Canopy", Respira exposes **197 MCP tools** on any WordPress site and **302** with the WooCommerce add-on installed (105 of those are `woocommerce_*` tools), alongside **269 WebMCP browser abilities** and **37 skills**. Those numbers were measured by booting the MCP server and calling `tools/list`. This reference documents the core categories and naming patterns.
 
 ## Tool Categories
 
@@ -212,6 +212,21 @@ Discover and edit Divi's global Theme Builder templates (headers, footers, and b
 - `respira_create_theme_builder_template` (write)
 - `respira_update_theme_builder_template` (write)
 
+### Site Editor / FSE (19 tools) <span style={{color: '#10b981'}}>NEW in 8.0</span>
+
+Read and write the native WordPress Site Editor: block templates and template parts, synced and unsynced patterns, block navigation, and global styles. Read-only discovery is available on any site with a block theme. **Structural writes are beta-gated per site and off by default.** See [Site Editor (Full Site Editing)](/builders/site-editor).
+
+- `respira_list_site_templates`, `respira_get_site_template`, `respira_create_site_template`, `respira_update_site_template`, `respira_reset_site_template`
+- `respira_list_site_patterns`, `respira_get_site_pattern`, `respira_create_site_pattern`, `respira_update_site_pattern`, `respira_delete_site_pattern`
+- `respira_list_site_navigations`, `respira_get_site_navigation`, `respira_create_site_navigation`, `respira_update_site_navigation`, `respira_delete_site_navigation`
+- `respira_list_design_tokens`, `respira_create_design_token`, `respira_update_design_token`, `respira_delete_design_token`
+
+### Activity (2 tools) <span style={{color: '#10b981'}}>NEW in 8.0</span>
+
+Agent-facing activity history that links audit entries to the snapshots, proposals, approvals, and rollbacks they belong to.
+
+- `respira_list_activity`, `respira_get_activity`
+
 ### Translations — WPML (3 tools) <span style={{color: '#10b981'}}>NEW in 7.6</span>
 
 Create and update WPML translations through the agent. A created translation joins the page's existing language group so WPML treats it as a real translation, and the builder content is carried across into the new copy.
@@ -249,10 +264,12 @@ Create and update WPML translations through the agent. A created translation joi
 | Elementor deep tools | 8 | 5 | 3 |
 | Theme Builder — Divi <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
 | Translations — WPML <span style={{color: '#10b981'}}>NEW in 7.6</span> | 3 | 1 | 2 |
+| Site Editor / FSE <span style={{color: '#10b981'}}>NEW in 8.0</span> | 19 | 7 | 12 |
+| Activity <span style={{color: '#10b981'}}>NEW in 8.0</span> | 2 | 2 | 0 |
 | WooCommerce (add-on) | 21 | 11 | 10 |
-| **Total** | **241** | **98** | **143** |
+| **Total** | **262** | **107** | **155** |
 
-> This table lists the documented core categories. The full MCP surface is **261 tools** (174 in core plans plus 87 in the WooCommerce add-on) alongside **229 WebMCP browser abilities** — see the live counts on [respira.press](https://respira.press).
+> This table lists documented categories, not the per-site surface. Some categories only register when the matching builder or add-on is present, so the column total is higher than what a single site sees. The measured surface is **197 tools** on any WordPress site, **302** with the WooCommerce add-on (105 `woocommerce_*` tools), alongside **269 WebMCP abilities** and **37 skills**. See the live counts on [respira.press](https://respira.press).
 
 ## Tool Naming Convention
 

--- a/troubleshooting.mdx
+++ b/troubleshooting.mdx
@@ -40,9 +40,9 @@ npx @respira/wordpress-mcp-server --setup
 
 ### Recommended version baseline
 
-- Respira for WordPress: `7.5+`
-- MCP server: `7.2+`
-- WooCommerce tooling: keep the WooCommerce add-on current alongside the plugin
+- Respira for WordPress: `8.0.0+`
+- MCP server: `8.0.0+`
+- WooCommerce add-on: `4.0.0+` (v4.0.0 requires plugin 8.0.0 or newer)
 
 Respira ships fixes almost every week, so the reliable baseline is simply the latest release of each. If you are on older versions, update first before deep debugging.
 

--- a/usage.mdx
+++ b/usage.mdx
@@ -58,7 +58,7 @@ Respira for WordPress transforms how you interact with your WordPress site by pr
 
 ## Working with Page Builders
 
-Respira supports 16 page builders. Each builder stores content differently, but Respira handles the translation automatically.
+Respira supports 16 page builders plus the native Site Editor. Each builder stores content differently, but Respira handles the translation automatically. For block themes, the site-level surface (templates, patterns, navigation, global styles) is covered on the [Site Editor](/builders/site-editor) page.
 
 ### Supported Builders
 

--- a/woocommerce/overview.mdx
+++ b/woocommerce/overview.mdx
@@ -1,11 +1,13 @@
 ---
 title: WooCommerce Add-on
-description: 87 AI tools for WooCommerce including agent-ready commerce (product feeds + llms.txt), storefront design intelligence, Subscriptions, Bookings and Memberships writes, STAGGS configurator editing, bulk pricing with snapshots, and catalog health audits. €95/year for Maker and Builder. Included free with Studio and Founder.
+description: 105 AI tools for WooCommerce including FSE-first storefront intelligence, agent-ready commerce (product feeds + llms.txt), Subscriptions, Bookings and Memberships writes, STAGGS configurator editing, bounded HPOS-compatible reporting, approval-gated webhooks, bulk pricing with snapshots, and catalog health audits. €95/year for Maker and Builder. Included free with Studio and Founder.
 ---
 
 ## Overview
 
-The Respira for WordPress WooCommerce Add-on extends Respira's safety-first workflow to your WooCommerce store. 87 tools (as of add-on v3.2) that connect commerce data to page builder visuals and make the store readable to AI shopping assistants, with a snapshot, a dry-run preview, and an approval step on every change.
+The Respira for WordPress WooCommerce Add-on extends Respira's safety-first workflow to your WooCommerce store. 105 WooCommerce tools (as of add-on v4.0.0) that connect commerce data to page builder visuals and make the store readable to AI shopping assistants, with a snapshot, a dry-run preview, and an approval step on every change.
+
+With the add-on installed, the total MCP surface on the site is 302 tools: the 197 available on any WordPress site plus the 105 `woocommerce_*` tools.
 
 **Pricing:**
 - **Studio and Founder plans:** included free, no separate purchase
@@ -18,6 +20,7 @@ No free trial on the WooCommerce add-on. The core Respira plugin has a 7-day tri
 **Requirements**
 
 - Respira Core installed and connected (Maker, Builder, Studio, or Founder plan)
+- Respira for WordPress plugin 8.0.0 or newer (required by add-on v4.0.0)
 - WooCommerce plugin active on the same site
 - WordPress 6.0 or newer
 - PHP 7.4 or newer
@@ -26,7 +29,40 @@ If you are not set up with Respira yet, start with the base [Installation](/inst
 
 </Callout>
 
-## What's included (87 tools)
+## New in v4.0.0: the storefront works on block themes
+
+Before v4.0.0, storefront intelligence assumed a page builder. On a block theme it found none and returned "no page builder detected", which meant the storefront tools were inert on exactly the stack WordPress core is pushing people toward.
+
+<Callout kind="info">
+
+That gap was found and documented, live-verified, by [Dale Smith of revWorx](https://revworx.ai/), who builds exclusively on FSE block themes and published the field study that drove this work.
+
+</Callout>
+
+**Storefront intelligence is now FSE-first with page-builder fallback**
+- On a block theme, analysing a shop page returns real structural analysis against the native `archive-product` template instead of an unsupported message
+- Where a page builder is present, the existing builder path still runs
+
+**Badges land where WooCommerce puts them**
+- Sale and low-stock badges are positioned inside the product image, matching WooCommerce's own product card rather than floating outside it
+- An existing badge means the write is **refused as a no-op** rather than duplicated. A second run does not stack a second badge
+
+**Product-card fields addressed by canonical block name**
+- Fields are addressed by the WooCommerce block name: `woocommerce/product-image`, `woocommerce/product-price`, `woocommerce/product-title`, `woocommerce/product-button`
+- Requested attributes are intersected with the installed block's registered attributes, so an unrecognised key is refused rather than silently accepted and dropped
+
+**Reporting**
+- Bounded, HPOS-compatible revenue reporting, sales time-series, top-product reporting, order reporting, and privacy-safe customer reporting
+
+**Read-only store discovery**
+- Store configuration, payment gateways, shipping zones and tax rates are readable. They stay read-only
+
+**Native webhook management, approval-gated**
+- Create and manage native WooCommerce webhooks: HTTPS targets only, allowlisted topics only, and secrets are write-only. Every webhook change goes through approval
+
+v4.0.0 requires Respira for WordPress plugin 8.0.0 or newer.
+
+## What's included (105 tools)
 
 The add-on grew from commerce CRUD into the full storefront layer. The areas:
 
@@ -61,8 +97,15 @@ The add-on grew from commerce CRUD into the full storefront layer. The areas:
 - Stock levels, stock status, and low-stock detection
 - An AI-readiness score (0-100) per product and across the catalog (`product_ai_readiness`, `catalog_ai_readiness`) so an agent knows what to fix before it sells
 
-**Storefront design intelligence**
-- Read your shop and product pages in the active builder, score them, and edit product cards and checkout layout through the builder abstraction. Supported on Elementor, Divi, Bricks, Flatsome, and Gutenberg; other builders return a clear unsupported message
+**Storefront design intelligence (FSE-first since v4.0)**
+- Read your shop and product pages, score them, and edit product cards and checkout layout. On a block theme this runs against the native `archive-product` template. Where a page builder is present the builder path is used instead: Elementor, Divi, Bricks, Flatsome, and Gutenberg. Other builders return a clear unsupported message
+
+**Store configuration and webhooks (v4.0)**
+- Read-only discovery of store configuration, payment gateways, shipping zones and tax rates
+- Approval-gated native WooCommerce webhook management: HTTPS targets, allowlisted topics, write-only secrets
+
+**Reporting (v4.0)**
+- Bounded, HPOS-compatible revenue reporting, sales time-series, top products, orders, and privacy-safe customer reporting
 
 **Catalog operations and pricing**
 - Advanced product filtering, bulk product and price updates (percentage, absolute, or set-value) with a 100-product cap and snapshots, catalog-health audits, natural-language product search, and snapshot-backed pricing rollback

--- a/woocommerce/safety.mdx
+++ b/woocommerce/safety.mdx
@@ -224,6 +224,25 @@ Treat payment, shipping, and tax settings as the legal and financial backbone of
 
 </Callout>
 
+### Store configuration discovery (read-only, v4.0)
+
+Add-on v4.0.0 makes store configuration, payment gateway, shipping zone and tax-rate discovery explicit tools. They are reads. Nothing in that group writes.
+
+## Webhooks: approval-gated, v4.0
+
+Add-on v4.0.0 adds native WooCommerce webhook management. A webhook sends your store's data to somewhere else, so it is the one v4.0 write path that leaves the site, and it is fenced accordingly:
+
+- **Approval-gated.** A webhook change is staged and a human approves it before it takes effect.
+- **HTTPS targets only.** A plain HTTP delivery URL is refused.
+- **Allowlisted topics only.** A topic outside the allowlist is refused.
+- **Write-only secrets.** A secret can be set but never read back, so it cannot be exfiltrated through a tool response.
+
+## Storefront writes: no-op instead of duplicate (v4.0)
+
+Storefront card writes are idempotent by refusal. If a sale or low-stock badge is already present on a product card, a second write is refused as a no-op rather than adding a second badge. Re-running the same prompt does not stack decoration on your product cards.
+
+Product-card fields are addressed by canonical WooCommerce block name, and requested attributes are intersected with the installed block's registered attributes. An unrecognised attribute key is refused rather than accepted and quietly dropped, so a write either does what you asked or tells you it did not.
+
 ## Permission controls and opt-in safety
 
 You stay in control of what the WooCommerce add-on can touch in your store.

--- a/woocommerce/tools.mdx
+++ b/woocommerce/tools.mdx
@@ -1,6 +1,6 @@
 ---
 title: WooCommerce Tools Reference
-description: Reference for WooCommerce MCP tools provided by the Respira for WordPress WooCommerce Add-on (87 tools), grouped by products, orders, inventory, feeds, extensions, configurators, and reports.
+description: Reference for WooCommerce MCP tools provided by the Respira for WordPress WooCommerce Add-on (105 tools), grouped by products, orders, inventory, storefront, feeds, extensions, configurators, reports, store configuration, and webhooks.
 ---
 
 ## How WooCommerce tools work with your AI assistant
@@ -13,7 +13,7 @@ Your AI assistant typically decides which tool to call based on natural language
 - Set guardrails for what the assistant is allowed to change
 - Review logs and audit which tools were used
 
-When the WooCommerce add-on is installed, the assistant has access to 87 WooCommerce tools (as of add-on v3.2) spanning products, variations and swatches, orders and refunds, coupons, customers, inventory, AI-readiness, storefront design intelligence, product feeds and llms.txt, cart links with agent-order attribution, Subscriptions, Bookings and Memberships, and the STAGGS product configurator. This page documents the primary product, order, inventory, and report tools, then lists the v3.1 and v3.2 groups; see the [overview](/woocommerce/overview) for the full list of areas.
+When the WooCommerce add-on is installed, the assistant has access to 105 `woocommerce_*` tools (as of add-on v4.0.0) spanning products, variations and swatches, orders and refunds, coupons, customers, inventory, AI-readiness, storefront design intelligence, product feeds and llms.txt, cart links with agent-order attribution, Subscriptions, Bookings and Memberships, the STAGGS product configurator, bounded reporting, read-only store configuration, and approval-gated webhooks. That brings the total MCP surface on the site to 302 tools: the 197 available on any WordPress site plus these 105. This page documents the primary product, order, inventory, and report tools, then lists the v3.1, v3.2 and v4.0 groups; see the [overview](/woocommerce/overview) for the full list of areas.
 
 <Callout kind="info">
 
@@ -376,7 +376,7 @@ If you run into issues with WooCommerce tools or need help designing workflows, 
 
 ## Complete tool list
 
-The add-on registers 87 WooCommerce MCP tools (as of v3.2): the `respira-woocommerce/` abilities plus the REST/MCP storefront-design, catalog, pricing, AI-readiness, feeds, cart-link, extension and configurator tools described in the [overview](/woocommerce/overview) and in the section below. Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
+The add-on registers 105 WooCommerce MCP tools (as of v4.0.0): the `respira-woocommerce/` abilities plus the REST/MCP storefront-design, catalog, pricing, AI-readiness, feeds, cart-link, extension, configurator, reporting, store-configuration and webhook tools described in the [overview](/woocommerce/overview) and in the sections below. Every write is snapshot-backed, runs behind the `manage_woocommerce` capability, and supports `dry_run` where it changes data.
 
 ### Products, categories, tags & brands
 
@@ -489,3 +489,44 @@ All extension writes are dry-run by default and require the real extension plugi
 - `woocommerce_configurator_status`, `woocommerce_get_product_configurator`, `woocommerce_set_product_configurator` — detect STAGGS, read and enable/disable the configurator per product
 - `woocommerce_list_configurator_attributes`, `woocommerce_get_configurator_attribute_items`, `woocommerce_set_configurator_attribute_items` — read attribute groups and rewrite option items (labels, prices, defaults) through the STAGGS/Carbon Fields helpers
 - `woocommerce_get_plugin_state`, `woocommerce_set_plugin_state` — allow-listed plugin settings; any key outside the known-safe set refuses the whole request
+
+## Storefront, reporting, configuration and webhooks (v4.0)
+
+v4.0.0 requires Respira for WordPress plugin 8.0.0 or newer.
+
+### Storefront intelligence, FSE-first
+
+Storefront analysis no longer assumes a page builder. On a block theme it runs against the native `archive-product` template and returns real structural analysis instead of "no page builder detected". Where a page builder is present, the existing builder path still runs.
+
+Two behaviours worth knowing before you call a storefront write:
+
+- **Badges land inside the product image.** Sale and low-stock badges are positioned inside the product image, matching WooCommerce's own product card. If a badge is already there, the write is **refused as a no-op** rather than duplicated, so re-running a prompt does not stack badges.
+- **Product-card fields are addressed by canonical block name.** Use the WooCommerce block name: `woocommerce/product-image`, `woocommerce/product-price`, `woocommerce/product-title`, `woocommerce/product-button`. Requested attributes are intersected with the installed block's registered attributes, so an unrecognised attribute key is refused rather than silently accepted and dropped.
+
+### Reporting
+
+Bounded, HPOS-compatible reporting. Every report has a hard bound so a broad question cannot walk the whole order table.
+
+- Revenue reporting over a date range
+- Sales time-series
+- Top-product reporting
+- Order reporting
+- Customer reporting, privacy-safe by default
+
+### Store configuration discovery (read-only)
+
+Read what the store is actually configured to do before changing anything around it. These are reads. They do not write.
+
+- Store configuration
+- Payment gateways
+- Shipping zones
+- Tax rates
+
+### Native WooCommerce webhooks (approval-gated)
+
+Webhook management is the one v4.0 write path that leaves your site, so it is fenced:
+
+- **Approval-gated.** A webhook change is staged for a human to approve.
+- **HTTPS targets only.** A plain HTTP delivery URL is refused.
+- **Allowlisted topics only.** A topic outside the allowlist is refused.
+- **Write-only secrets.** A secret can be set, never read back.


### PR DESCRIPTION
Documents Respira 8.0 "Canopy", shipped 2026-07-26. Plugin 8.0.0, MCP server 8.0.0, WooCommerce add-on 4.0.0.

**Do not merge until reviewed.** Documentation.AI publishes on every commit to `main` and fails silently on an unsupported MDX component, so this is a PR rather than a push.

## New page

`builders/site-editor.mdx`, registered in `documentation.json` under Page Builders as "Site Editor (FSE)", right after Gutenberg.

Covers block templates and template parts with hierarchy and source discovery, synced and unsynced patterns (registered theme/plugin patterns stay read-only), block navigation edited by exact block path with guessed-path and stale-revision refusals, Gutenberg design tokens, the structural write safety contract (fingerprint, snapshot, read-back, server-render verify), structural proposals, the mutation-result contract, activity history, and the per-site beta gate.

## Stale facts corrected

| Where | Was | Now |
|---|---|---|
| tool counts across the corpus | 261 / 254 / 234 | **197** on any WordPress site, **302** with the Woo add-on |
| WooCommerce tool count | 87 | **105** (`woocommerce_*`) |
| WebMCP abilities | 229 | **269** |
| desktop MCP inventory (browser-ai) | 82 WP + 21 Woo, "100+ tools" | 197 / 302 / 269 abilities |
| newest plugin changelog entry | v7.5.18 | **v8.0.0 "Canopy"** |
| newest MCP server changelog entry | v3.3.5, dated 2026-03-07 | **v8.0.0**, dated 2026-07-26 |
| newest Woo add-on changelog entry | v3.2.0 | **v4.0.0** |
| version baseline (troubleshooting) | plugin 7.5+, server 7.2+ | plugin 8.0.0+, server 8.0.0+, add-on 4.0.0+ |
| coverage line | "16 page builders" | "16 page builders plus the native Site Editor" |
| Gutenberg FSE coverage | 9 lines, 2 of them Limitations that 8.0 falsifies | first-class, with the gate stated |

## Rewritten

- `builders/gutenberg.mdx`: FSE section rebuilt, patterns section corrected (registered theme/plugin patterns are read-only), false limitations replaced, 8.0 capabilities added
- `builders/divi.mdx`: the Theme Builder live-edit confirmation handshake (`respira_tb_live_edit_confirmation_required`, then `confirm_live_edit=true`), documented explicitly as a confirmation and **not** an approval, plus the two safety fixes found by auditing the safety layer
- `woocommerce/overview.mdx`, `tools.mdx`, `safety.mdx`: FSE-first storefront intelligence with page-builder fallback, badges inside the product image with an existing badge refused as a no-op, product-card fields by canonical block name with attributes intersected against the installed block, bounded HPOS-compatible reporting, read-only store config discovery, approval-gated webhooks (HTTPS only, allowlisted topics, write-only secrets), plugin 8.0.0+ requirement
- `safety-philosophy.mdx`: the structural write contract, the mutation-result table, the beta gate, and the confirmation-is-not-approval distinction

## Credit

The FSE work traces to a published field study by Dale Smith of [revWorx](https://revworx.ai/), credited on the Site Editor page, the Gutenberg page, the WooCommerce overview, and both changelog entries.

## Deploy safety checks

- `documentation.json` parses: `node -e "JSON.parse(...)"` returns valid
- 158 nav paths checked, 0 missing
- only `<Callout>` and `<Update>` introduced in the diff. No `<Warning>`, `<Note>`, `<Info>`, `<Tip>` anywhere
- no em or en dashes, no exclamation marks, no "we/our/us", no capital-I first person in any added line
- bare nav-group paths left alone as designed

## Deliberately left alone

- historical changelog entries keep their period-accurate numbers ("Twelve builders" in the v6.0 entry, 87 tools in the v3.2 entry)
- the corpus-wide em dash purge (out of scope, would bloat the diff)
- `duplicate-before-edit-workflow.mdx` is a pre-existing 0-byte file registered in nav
