### PR TITLE
docs: fill three pages that were registered in nav but empty

### DIFF
--- a/duplicate-before-edit-workflow.mdx
+++ b/duplicate-before-edit-workflow.mdx
@@ -1,0 +1,83 @@
+---
+title: Duplicate-Before-Edit Workflow
+description: How Respira stages a page edit on a duplicate, why the original stays untouched until you approve, and when a write goes live directly.
+---
+
+## Overview
+
+When an AI assistant edits a page through Respira, the edit does not land on your live page. Respira creates a duplicate, writes to the duplicate, and leaves the original exactly as it was until a human approves the change.
+
+This is the default for everything page-shaped: pages, posts, and custom post types.
+
+**What you'll learn**
+
+- What actually happens to your live page when an agent edits it
+- Where you approve or reject a staged change
+- When a write goes live directly instead, and how to tell in advance
+
+## Why staging rather than undo
+
+Undo is a promise you make after the damage. Staging is a promise you make before it.
+
+An agent that edits live and rolls back on failure still leaves a window where your page is wrong, and it depends on the agent noticing. Staging removes the window: the visitor-facing page does not change until a person says so.
+
+Respira keeps both. Staged writes are the default, and snapshots sit underneath for the cases where a write does go live.
+
+## The flow
+
+<Steps>
+
+<Step title="The agent asks to edit a page" icon="pencil">
+You ask your assistant to change something. It calls a write tool such as `respira_update_page` or `respira_update_element`.
+</Step>
+
+<Step title="Respira creates a duplicate" icon="copy">
+The duplicate is a real WordPress post, marked as a Respira duplicate and linked back to the original. The original is not modified. You can keep working on it in WordPress while the duplicate exists.
+</Step>
+
+<Step title="The write lands on the duplicate" icon="check">
+Builder content, styling and metadata are written to the duplicate. The agent gets back the duplicate's ID and preview URL, so it can show you what changed before you decide.
+</Step>
+
+<Step title="You approve or reject in WordPress" icon="user">
+Approving copies the duplicate's content onto the original and cleans the duplicate up. Rejecting discards the duplicate and leaves the original untouched.
+</Step>
+
+</Steps>
+
+## Where approval happens
+
+Approval is a WordPress admin action, not an agent action. You approve from the Respira screens inside wp-admin.
+
+<Callout kind="info">
+
+This is deliberate and worth stating plainly: `approve_duplicate`, `reject_duplicate` and `detach_duplicate` exist in the plugin's REST layer but are **not** exposed as MCP tools. An agent can create and fill a duplicate. It cannot approve its own work.
+
+</Callout>
+
+So an assistant cannot talk itself into publishing. The approval step needs a person in WordPress, which is the whole point of the design.
+
+## When a write goes live directly
+
+Staging is the default, not the only path. Some writes go straight to the live object, and Respira says which before it does.
+
+**Editing an original on purpose.** If you want the agent to edit the live page rather than a duplicate, the site needs Direct Editing enabled, and the call has to carry both `force=true` and `confirm_live_edit=true`. An attempt without them is refused with a `confirmation_required` response naming what would change. Direct Editing is off by default.
+
+**Site-level structures.** Templates, patterns, navigation and global styles are not pages and have no duplicate to stage on. They use structural proposals instead: a write can be parked as a pending proposal for you to approve, and every write is fingerprint-checked, snapshotted, read back, and server-render verified. Structural writes are beta-gated per site and off by default.
+
+**Divi Theme Builder global layouts.** These are snapshotted and reversible but written live, because Divi resolves a global layout by ID and a duplicate would compete with the original rather than stand in for it. The first attempt is refused and names the blast radius; re-sending with `confirm_live_edit=true` proceeds. That is a confirmation, not an approval.
+
+## What a duplicate is not
+
+A duplicate is not a revision, and not a draft of the original. It is a separate post that Respira tracks. Two consequences worth knowing:
+
+- It appears in your posts list while it exists, marked as a Respira duplicate
+- If you never approve or reject it, it stays there. Rejecting is the tidy way to say no
+
+To keep a duplicate as a standalone page rather than merge it back, detach it. Detaching breaks the link to the original and leaves you with an ordinary page.
+
+## Related
+
+<Card title="Safety philosophy" href="/docs/safety-philosophy" icon="shield">
+The full safety contract: snapshots, verification states, and what "verified" means.
+</Card>

--- a/toolkits/divi-5-migration-copilot.mdx
+++ b/toolkits/divi-5-migration-copilot.mdx
@@ -1,0 +1,70 @@
+---
+title: Divi 5 Migration Copilot
+description: The wp-admin screen that scans your site for Divi 5 readiness, builds a prompt pack from what it finds, and exports it as Markdown.
+---
+
+## Overview
+
+Respira helps you plan and validate your Divi 5 migration. Divi's Migrator performs the actual conversion.
+
+The Migration Copilot is the WordPress admin screen that ties the readiness scan and the prompt pack together. It looks at your actual site, then hands you prompts written against what it found rather than generic advice.
+
+**What you'll learn**
+
+- Where to find the Copilot and what it does
+- How the prompt pack is built from your own site's data
+- How to export the pack and use it outside WordPress
+
+<Callout kind="info">
+
+The Copilot plans, validates and generates prompts. It never converts a page. The Divi 4 to Divi 5 conversion is done by Divi's own Migrator.
+
+</Callout>
+
+## Where to find it
+
+The Copilot lives in wp-admin under the Respira menu, on the Divi 5 Migration Copilot screen. It appears on sites running Divi.
+
+## What it does
+
+<Steps>
+
+<Step title="Scans the site" icon="magnifying-glass">
+Generates the readiness report: the Divi 4 / Divi 5 / mixed split, high-risk pages, migration candidates, and unrecognised shortcodes. The report is cached per user for 24 hours, and the screen has a button to regenerate it on demand.
+</Step>
+
+<Step title="Builds a prompt pack from your results" icon="wand-magic-sparkles">
+The prompts are generated from your report, not from a fixed template. A site with many Compatibility Mode pages gets different prompts from a site whose main risk is unknown shortcodes.
+</Step>
+
+<Step title="Exports as Markdown" icon="file-arrow-down">
+The pack exports to Markdown so you can paste it into any AI assistant, keep it in a project brief, or hand it to a client alongside a quote.
+</Step>
+
+</Steps>
+
+## Why generate prompts rather than just a report
+
+A readiness report tells you what is risky. It does not tell you what to do next, and the useful next step depends on what the scan actually found.
+
+Generating the prompts from the report closes that gap. The output is specific to the site in front of you: which pages to migrate first, what to check after the Migrator runs, which layouts are worth modernising rather than converting as-is.
+
+## Using it with an agent
+
+The same underlying report is available to your AI assistant through `respira_get_divi_migration_readiness`, so you do not have to work in wp-admin if you would rather ask questions conversationally. The Copilot screen is the place to generate the export and see everything at once.
+
+## What this does not do
+
+- It does not migrate anything. Divi's Migrator performs the conversion.
+- It does not modify pages, settings or layouts. Generating a report and a prompt pack is read-only.
+- It does not replace a backup or a staging site. Plan both before you convert.
+
+## Related
+
+<Card title="Divi 5 Migration Readiness Report" href="/docs/toolkits/divi-5-migration-readiness-report" icon="chart-bar">
+What the scan reports and how to read each section.
+</Card>
+
+<Card title="Divi 5 Migration Prompt Pack" href="/docs/toolkits/divi-5-migration-prompt-pack" icon="list">
+The five structured prompts, with guidance on when to use each.
+</Card>

--- a/toolkits/divi-5-migration-readiness-report.mdx
+++ b/toolkits/divi-5-migration-readiness-report.mdx
@@ -1,0 +1,72 @@
+---
+title: Divi 5 Migration Readiness Report
+description: Generate a readiness report that counts Divi 4, Divi 5 and mixed pages, flags high-risk layouts, and tells you what would break before you migrate.
+---
+
+## Overview
+
+Respira helps you plan and validate your Divi 5 migration. Divi's Migrator performs the actual conversion.
+
+The readiness report answers one question before you touch production: what on this site would not survive a migration cleanly.
+
+**What you'll learn**
+
+- How to generate the report, from wp-admin or through your AI assistant
+- What each section of the report means
+- What the report deliberately does not do
+
+<Callout kind="info">
+
+The report plans and validates. It does not convert anything. Running it changes no pages.
+
+</Callout>
+
+## Generating the report
+
+There are two ways in, and they produce the same report.
+
+**From your AI assistant.** Ask a question like "is my site ready for Divi 5", "should i migrate to Divi 5", or "what would break if i migrated". The assistant calls `respira_get_divi_migration_readiness` and shapes the result into an answer.
+
+**From WordPress.** Open the Divi 5 Migration Copilot screen in wp-admin and generate the report there.
+
+The report is cached per user for 24 hours, so asking twice in a session does not rescan the site. Generate it again from the admin screen when you want fresh numbers.
+
+## What the report contains
+
+<Steps>
+
+<Step title="Version split" icon="chart-bar">
+How many pages are Divi 4, how many are already Divi 5, and how many are mixed. Mixed pages are the ones that usually surprise people: a page can carry both formats at once.
+</Step>
+
+<Step title="High-risk pages" icon="triangle-exclamation">
+Pages flagged as likely to need manual attention, including pages sitting in Compatibility Mode and pages using deprecated shortcodes.
+</Step>
+
+<Step title="Migration candidates" icon="list-check">
+The pages that look safe to migrate first. Useful for picking a low-stakes page to prove the process before touching anything important.
+</Step>
+
+<Step title="Unknown shortcodes" icon="magnifying-glass">
+A tally of shortcodes the scan does not recognise. These are not necessarily broken, but they are the things nobody can promise for you, so they are surfaced rather than hidden.
+</Step>
+
+</Steps>
+
+## Reading the result
+
+The tool returns structured data rather than prose, and your assistant turns it into a readable answer. That means you can ask follow-up questions against the same report: which pages are highest risk, what is the smallest safe first migration, what is the total mixed-format count.
+
+The disclaimer is part of the output and is meant to be surfaced verbatim rather than paraphrased away. Respira plans and validates. Divi's Migrator converts.
+
+## What this does not do
+
+- It does not migrate anything. No page is written and no format is changed.
+- It does not guarantee a clean migration. An unknown shortcode is reported as unknown, not silently judged safe.
+- It does not replace a backup. Take one before you run Divi's Migrator regardless of what the report says.
+
+## Related
+
+<Card title="Divi 5 Migration Prompt Pack" href="/docs/toolkits/divi-5-migration-prompt-pack" icon="list">
+Five structured prompts for planning, validating and cleaning up the migration.
+</Card>


### PR DESCRIPTION
All three were 0-byte files listed in `documentation.json`. They resolved, so the nav path check passed, and they served a 200 with the full page shell and no content. A blank page with a title in the sidebar reads as a broken product rather than an unwritten doc.

Found while validating the 8.0 nav.

- **duplicate-before-edit-workflow** — the core safety concept. Documents that `approve_duplicate` / `reject_duplicate` / `detach_duplicate` exist in the plugin REST layer but are deliberately NOT exposed as MCP tools, so an agent can create and fill a duplicate and cannot approve its own work. Also covers the three cases where a write does go live.
- **toolkits/divi-5-migration-readiness-report** — what `respira_get_divi_migration_readiness` returns, and the 24h per-user cache.
- **toolkits/divi-5-migration-copilot** — the wp-admin screen. I nearly deleted this nav entry assuming the feature did not exist, since no MCP tool matches the name. It does exist (`class-respira-divi-migration-copilot.php`): it generates the report, builds a prompt pack from that report rather than a template, and exports Markdown.

Components used: Callout, Card, Steps, Step. All on the known-safe list.