### PR TITLE
docs: GreenShift as the 17th supported page builder

### DIFF
--- a/builders/greenshift.mdx
+++ b/builders/greenshift.mdx
@@ -1,0 +1,78 @@
+---
+title: "GreenShift"
+description: "How Respira reads and writes GreenShift natively. GreenShift is one of Respira's 17 supported page builders, edited as native WordPress blocks, with the CSS and saved-markup rules GreenShift needs handled for you."
+---
+
+# GreenShift
+
+Technical documentation for using Respira with [GreenShift](https://go.respira.cafe/greenshift) by Wpsoul, which now ships as **GL - Page Builder** while keeping the `greenshift-blocks/` namespace internally.
+
+GreenShift is a block-native builder built around one very flexible block, `greenshift-blocks/element`, which can render any HTML tag. It is one of Respira's 17 supported page builders, with full read and write, and support covers the core builder **and all five add-ons**: GSAP animation, Query and Meta, WooCommerce, SEO, and Chart. They all register under the same namespace.
+
+<Note>
+  The GreenShift link above is an affiliate link. It costs you nothing and does not affect which builders Respira supports or how well it supports them.
+</Note>
+
+## Data structure
+
+GreenShift stores content as native WordPress blocks in `post_content`, the same as any Gutenberg page:
+
+```html
+<!-- wp:greenshift-blocks/element {"tag":"div","type":"inner","localId":"gsbp-a1"} -->
+<div class="gsbp-a1">
+  <!-- wp:greenshift-blocks/element {"tag":"h2","type":"text","textContent":"Welcome","localId":"gsbp-a2"} -->
+  <h2 class="gsbp-a2">Welcome</h2>
+  <!-- /wp:greenshift-blocks/element -->
+</div>
+<!-- /wp:greenshift-blocks/element -->
+```
+
+Two things about that markup matter more than they look, and they are the reason GreenShift needs its own handling rather than being treated as plain Gutenberg.
+
+### The text lives in the markup, not only in the attribute
+
+GreenShift elements are **static blocks**: what renders is the HTML saved between the block delimiters. `textContent` exists for the editor. A write that sets attributes alone stores a perfectly valid block and produces a page with nothing visible on it.
+
+Respira builds that saved markup for you, from the tag, the classes, the link and media attributes, and the text.
+
+### The CSS is derived, not stored
+
+GreenShift does not keep per-element CSS in the block. It derives it from `styleAttributes` and `dynamicGClasses`, and only emits it when either the page CSS meta (`_gspb_post_css`) is populated, or the block carries `"CSSRender":"1"`. For patterns, templates and template parts, the second is the only option, since those are not posts and have no page CSS meta.
+
+So a plain block write stores correctly and renders **completely unstyled**. Respira stamps `CSSRender` on every block that carries GreenShift styling, which lets the plugin generate its own CSS at render time, at whatever version you are running.
+
+## Responsive values
+
+Every `styleAttributes` value is a per-breakpoint array, in the order `["desktop", "tablet", "mobile_landscape", "mobile_portrait"]`. A desktop-only value is a **one-element** array, not a padded one:
+
+```json
+{ "styleAttributes": { "padding": ["40px"], "color": ["rgb(12,34,56)", "rgb(90,90,90)"] } }
+```
+
+If your agent sends a plain string, Respira converts it to the single-element form and notes that it did. Trailing empty values are trimmed, because the padded form is not what GreenShift expects.
+
+## Priming
+
+Prime once at the start of a session so the agent builds in GreenShift blocks rather than raw HTML:
+
+> *"This is a GreenShift site. Build and edit with greenshift-blocks/element and core blocks, not raw HTML, and duplicate any live page before editing."*
+
+## What Respira can do
+
+- Read the full block structure of any GreenShift page, including all add-on blocks
+- Update text, tags, classes, links, images and styling on any `greenshift-blocks/*` block
+- Build new pages and sections that render **styled**, not just stored
+- Find blocks by type, content match, or anchor
+- Preserve existing attributes and styling on every write
+
+## Known limits
+
+- **`customJs` does not execute from the block attribute.** GreenShift loads block scripts from the `gspb_block_js` site option, keyed by block id, so a `customJs` value written programmatically is stored and never runs. Respira warns rather than silently dropping it. Use a `core/html` block with a real `<script>` tag instead.
+- **`type: "text"` with no `textContent`** renders an empty tag. Respira warns that the element will be invisible. Use `type: "no"` if you want a deliberate spacer.
+- The **Query and Meta add-on** (`greenshiftquery` 5.9.7) currently conflicts with GL - Page Builder 3.3.3 at the PHP level: both declare `gspb_get_post_object_by_id()`. This is a GreenShift-side conflict, reported upstream; WordPress's activation sandbox catches it, so the site stays healthy and the add-on simply will not activate alongside that core version.
+
+## Verified against
+
+GL - Page Builder 3.3.3, with the GSAP (3.7.7), WooCommerce (2.4), SEO (1.0.3) and Chart (1.2.3) add-ons, on WordPress 7.0.2 / PHP 8.3.32 with WooCommerce 10.9.4 and a block theme. Added in Respira 8.2.0.
+
+For the shared block workflow, block identification and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).

--- a/builders/overview.mdx
+++ b/builders/overview.mdx
@@ -7,7 +7,7 @@ description: "How Respira edits 16 WordPress page builders plus the native Site 
 
 Respira understands 16 WordPress page builders at the module level, plus the native Site Editor. AI can update specific sections, buttons, or text blocks without affecting the rest of your page.
 
-As of 8.0 "Canopy" the coverage line is **16 page builders plus the native Site Editor**.
+As of 8.2 the coverage line is **17 page builders plus the native Site Editor**.
 
 ## Supported Builders
 
@@ -28,6 +28,7 @@ As of 8.0 "Canopy" the coverage line is **16 page builders plus the native Site 
 | [Spectra](/builders/spectra) | Blocks | Blocks | ✓ Full |
 | [Kadence Blocks](/builders/kadence-blocks) | Blocks | Blocks | ✓ Full |
 | [GenerateBlocks](/builders/generateblocks) | Blocks | Blocks | ✓ Full |
+| [GreenShift](/builders/greenshift) | Blocks | Blocks | ✓ Full |
 | [SeedProd](/builders/seedprod) | Blocks | Blocks | Audit only |
 
 Plus the native WordPress Site Editor:
@@ -36,7 +37,7 @@ Plus the native WordPress Site Editor:
 |--------|---------|-------------|---------|
 | [Site Editor (FSE)](/builders/site-editor) | Templates, template parts, patterns, navigation, global styles | Block markup / `theme.json` | Read everywhere. Structural writes beta-gated per site |
 
-> Divi covers Divi 4 and Divi 5; Oxygen covers Oxygen Classic and Oxygen 6. With those variants, that is **16 builders** with full read and write. SeedProd is audit-only (agents read and report on landing pages). Brizy and Visual Composer moved from read to write in Respira 7.4.0 "Clearing". The native Site Editor became a first-class target in Respira 8.0 "Canopy" and is counted separately from the 16 builders.
+> Divi covers Divi 4 and Divi 5; Oxygen covers Oxygen Classic and Oxygen 6. With those variants, that is **17 builders** with full read and write. SeedProd is audit-only (agents read and report on landing pages). Brizy and Visual Composer moved from read to write in Respira 7.4.0 "Clearing". The native Site Editor became a first-class target in Respira 8.0 "Canopy" and is counted separately from the 17 builders.
 
 ### New in 8.0 "Canopy": the native Site Editor
 
@@ -116,7 +117,7 @@ Yes. Respira detects Divi Global Modules and can update them. Changes to global 
 
 ### Does Respira work with custom builder modules?
 
-Core modules from all 16 builders are fully supported. Third-party add-on modules have varying support depending on how they store data. Most text-based custom modules work well.
+Core modules from all 17 builders are fully supported. Third-party add-on modules have varying support depending on how they store data. Most text-based custom modules work well.
 
 ### What happens to my styling when Respira updates a module?
 

--- a/builders/site-editor.mdx
+++ b/builders/site-editor.mdx
@@ -7,7 +7,7 @@ description: "How Respira reads and writes the native WordPress Site Editor: blo
 
 Respira 8.0 "Canopy" makes the native WordPress Site Editor a first-class target. Before 8.0, a block theme was a blind spot: Respira could read and write a page's blocks, but the things that actually define a block theme site, the templates, the template parts, the patterns, the navigation and the global styles, were not addressable.
 
-That gap is closed. The positioning line for 8.0 is **16 page builders plus the native Site Editor**.
+That gap is closed. The positioning line for 8.0 is **17 page builders plus the native Site Editor**.
 
 <Callout kind="info">
 

--- a/documentation.json
+++ b/documentation.json
@@ -954,6 +954,11 @@
                 "icon": "layout"
               },
               {
+                "title": "GreenShift",
+                "path": "builders/greenshift",
+                "icon": "layout"
+              },
+              {
                 "title": "SeedProd",
                 "path": "builders/seedprod",
                 "icon": "layout"

--- a/inhale-mcp-abilities/about-mcp-and-anthropic.mdx
+++ b/inhale-mcp-abilities/about-mcp-and-anthropic.mdx
@@ -32,7 +32,7 @@ If you represent Anthropic, the WordPress Foundation, or any other rights holder
 
 ## About Respira
 
-Respira is an independent company that ships AI infrastructure for WordPress. Inhale: MCP Abilities is offered free; Respira's commercial work centers on **Respira for WordPress**, a paid safety layer for AI-driven edits across 16 page builders.
+Respira is an independent company that ships AI infrastructure for WordPress. Inhale: MCP Abilities is offered free; Respira's commercial work centers on **Respira for WordPress**, a paid safety layer for AI-driven edits across 17 page builders.
 
 Inhale: MCP Abilities and Respira for WordPress are technically and commercially separate. Inhale: MCP Abilities will continue to work whether or not you ever install Respira for WordPress.
 

--- a/inhale-mcp-abilities/faq.mdx
+++ b/inhale-mcp-abilities/faq.mdx
@@ -26,7 +26,7 @@ That said, treat the abilities you inhale the same way you'd treat any other API
 
 ## What's the relationship between Inhale: MCP Abilities and Respira?
 
-Inhale: MCP Abilities is a free utility built and maintained by Respira. Respira's main product is **Respira for WordPress**, a paid safety layer for AI-driven edits across 16 page builders (Elementor, Bricks, Divi, Breakdance, Oxygen, Beaver Builder, etc.).
+Inhale: MCP Abilities is a free utility built and maintained by Respira. Respira's main product is **Respira for WordPress**, a paid safety layer for AI-driven edits across 17 page builders (Elementor, Bricks, Divi, Breakdance, Oxygen, Beaver Builder, etc.).
 
 The two products are completely separate. You can use the Inhale: MCP Abilities plugin forever without ever using Respira for WordPress, and many users will. Inhale: MCP Abilities is offered to the WordPress community as a small contribution back to the ecosystem.
 

--- a/inhale-mcp-abilities/overview.mdx
+++ b/inhale-mcp-abilities/overview.mdx
@@ -26,7 +26,7 @@ Inhale: MCP Abilities is one of three layers Respira ships for WordPress:
 | Layer | What it is | Where it lives |
 |---|---|---|
 | **Inhale: MCP Abilities** | Free utility, choose which abilities are MCP-visible | Settings → Inhale: MCP Abilities |
-| **Respira for WordPress** | Paid plugin, safety layer for AI-driven edits across 16 page builders | Respira menu in wp-admin |
+| **Respira for WordPress** | Paid plugin, safety layer for AI-driven edits across 17 page builders | Respira menu in wp-admin |
 | **respira.press** | Marketing site and these docs | Public |
 
 You can run Inhale: MCP Abilities without ever installing Respira for WordPress. The two products are separate; Inhale: MCP Abilities is a community contribution.

--- a/introduction.mdx
+++ b/introduction.mdx
@@ -15,7 +15,7 @@ Respira is a safe bridge between your AI coding assistant and WordPress. It tran
 
 - Safely lets [Claude Cowork](https://respira.press/cowork), [Cursor](https://cursor.com), [Claude Code](https://claude.ai), [Windsurf](https://codeium.com/windsurf), and other AI coding assistants edit WordPress
 - Uses a duplicate-first workflow so AI edits copies; you approve before anything goes live
-- Understands 16 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd, plus [block templates, patterns, navigation and global styles](/builders/site-editor)
+- Understands 17 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, GreenShift, and SeedProd, plus [block templates, patterns, navigation and global styles](/builders/site-editor)
 - 197 MCP tools on any WordPress site, 302 with the WooCommerce add-on (105 `woocommerce_*` tools), covering ACF, the Site Editor, element-level editing, page building, stock images, and tool governance
 - 269 WebMCP abilities and 37 skills
 - Requires no SSH or complex hosting setup—works on typical shared hosting
@@ -162,7 +162,7 @@ You have successfully connected your AI coding assistant to WordPress.
 - [Configuration](/configuration)
 - [Usage Guide](/usage)
 - [Tools Reference](/tools/overview) - Tool categories, naming, and usage guidance
-- [Page Builder Support](/builders/overview) - How Respira works with 16 builders
+- [Page Builder Support](/builders/overview) - How Respira works with 17 builders
 - [Site Editor (Full Site Editing)](/builders/site-editor) - Templates, patterns, navigation, global styles
 - [Prompts & Examples](/prompts)
 - [Troubleshooting](/troubleshooting)
@@ -213,4 +213,4 @@ Yes. Respira offers a free trial. You can start without entering payment details
 
 ### Which page builders does Respira support?
 
-Respira supports 16 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, and SeedProd. Since 8.0 "Canopy", block themes are covered at the site level too: templates, patterns, navigation and global styles. See [Page Builder Support](/builders/overview) for the full matrix and [Site Editor](/builders/site-editor) for the FSE surface.
+Respira supports 17 page builders plus the native Site Editor, including Gutenberg, Elementor, Divi 4 and 5, Bricks, Oxygen, Beaver Builder, Breakdance, Brizy, WPBakery, Visual Composer, Flatsome, Spectra, Kadence Blocks, GenerateBlocks, GreenShift, and SeedProd. Since 8.0 "Canopy", block themes are covered at the site level too: templates, patterns, navigation and global styles. See [Page Builder Support](/builders/overview) for the full matrix and [Site Editor](/builders/site-editor) for the FSE surface.

--- a/support/faq.mdx
+++ b/support/faq.mdx
@@ -31,9 +31,9 @@ Yes. Respira offers a free trial. You can start without entering payment details
 
 ## Which page builders does Respira support?
 
-Respira supports 16 page builders with full read and write: Gutenberg, Elementor, Divi 4, Divi 5, Bricks, Oxygen Classic, Oxygen 6, Beaver Builder, Breakdance, Flatsome, Brizy, Visual Composer, WPBakery, Spectra, Kadence Blocks, and GenerateBlocks. SeedProd is audit-only (agents read and report on landing pages), and Thrive Architect supports text edits.
+Respira supports 17 page builders with full read and write: Gutenberg, Elementor, Divi 4, Divi 5, Bricks, Oxygen Classic, Oxygen 6, Beaver Builder, Breakdance, Flatsome, Brizy, Visual Composer, WPBakery, Spectra, Kadence Blocks, GenerateBlocks, and GreenShift. SeedProd is audit-only (agents read and report on landing pages), and Thrive Architect supports text edits.
 
-Since 8.0 "Canopy" the native WordPress Site Editor is covered too, which makes the line "16 page builders plus the native Site Editor". On a block theme that means block templates and template parts, synced and unsynced patterns, block navigation, and global styles. Read-only discovery works everywhere; structural writes to those site-level objects are beta-gated per site and off by default. See [Site Editor](/builders/site-editor).
+Since 8.0 "Canopy" the native WordPress Site Editor is covered too, which makes the line "17 page builders plus the native Site Editor". On a block theme that means block templates and template parts, synced and unsynced patterns, block navigation, and global styles. Read-only discovery works everywhere; structural writes to those site-level objects are beta-gated per site and off by default. See [Site Editor](/builders/site-editor).
 
 ## I see `respira_mcp_update` in responses. Is that an error?
 

--- a/usage.mdx
+++ b/usage.mdx
@@ -58,7 +58,7 @@ Respira for WordPress transforms how you interact with your WordPress site by pr
 
 ## Working with Page Builders
 
-Respira supports 16 page builders plus the native Site Editor. Each builder stores content differently, but Respira handles the translation automatically. For block themes, the site-level surface (templates, patterns, navigation, global styles) is covered on the [Site Editor](/builders/site-editor) page.
+Respira supports 17 page builders plus the native Site Editor. Each builder stores content differently, but Respira handles the translation automatically. For block themes, the site-level surface (templates, patterns, navigation, global styles) is covered on the [Site Editor](/builders/site-editor) page.
 
 ### Supported Builders
 


### PR DESCRIPTION
Adds GreenShift as the 17th supported page builder, shipped in Respira 8.2.0.

## What is here

- New `builders/greenshift.mdx` plus its nav entry in `documentation.json`
- Coverage line moved from 16 to 17 across `introduction`, `builders/overview`, `builders/site-editor`, `usage`, `support/faq` and the three `inhale-mcp-abilities` pages
- GreenShift added to the builder matrix and to the name lists that enumerate builders

## Why the page reads the way it does

GreenShift is block-native, so most of it works through the existing Gutenberg path. Two things do not, and both are ways a write can look successful and be wrong, so the page leads with them:

1. **Its elements are static blocks.** The text has to live in the saved markup, not only in the `textContent` attribute. Attributes alone store a valid block and render an empty page.
2. **Its CSS is derived, not stored.** GreenShift builds CSS from `styleAttributes` / `dynamicGClasses` and only emits it when the page CSS meta is populated or the block carries `CSSRender`. A plain block write renders completely unstyled.

Also documented: the responsive array shape, that `customJs` never executes from the block attribute, and a vendor-side function collision between `greenshiftquery` 5.9.7 and GL - Page Builder 3.3.3 that we hit while testing.

## Verification

Written against a live stack: GL - Page Builder 3.3.3 with the GSAP, WooCommerce, SEO and Chart add-ons, WordPress 7.0.2, PHP 8.3.32, WooCommerce 10.9.4, block theme. `documentation.json` re-parsed after the nav edit.

The GreenShift link is an affiliate link and the page discloses that inline.
