### PR TITLE
docs(builders): write hazards, per builder, with the symptom you would actually see

### DIFF
--- a/builders/beaver-builder.mdx
+++ b/builders/beaver-builder.mdx
@@ -129,6 +129,60 @@ Beaver Themer layouts (headers, footers, archives) are fully supported:
 - **Field connections**: Beaver Themer field connections are preserved but not directly editable
 - **Third-party modules**: Support varies by add-on; core modules have full support
 
+## Write hazards
+
+Reproduced ways a Beaver Builder write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### A build that reported success and rendered a blank page
+
+**What goes wrong.** Beaver's own front end renderer will not output anything for a row that has no column-group under it. A typed `row` node whose `columns` or `cols` key held column specs, which is the documented shape, skipped the mandatory column-group synthesis. The stored data looked populated and every safety check agreed.
+
+**What you see.** `_fl_builder_data` with row and column nodes, a non-zero element count, a passing render check, and a page that renders nothing at all. Two related faults shipped in the same state: a column's declared `size` was dropped, so multi-column layouts always came out equal-width, and an inject with a top-level `{"rows": [...]}` payload collapsed a whole multi-row layout into one empty node while the response counted the real, unwritten structure. "23 elements written" next to a blank page.
+
+**Status.** All three fixed in 7.5.50 at the shared conversion path.
+
+**What to do.** If a Beaver build came back blank, do not resend the same payload. Extract the page and check whether a column-group exists under each row.
+
+### A multi-row layout collapsing into a single stacked column
+
+**What goes wrong.** The auto-wrap pass decided whether to wrap the top level node list in a synthetic row, column-group and column using one flag for the whole array. An orphaned module, a node whose `parent` points at an id no longer in the tree, is promoted to root during simplification, and its presence flipped that flag for every other top level node too. Every legitimate row got pulled inside one synthetic column alongside it.
+
+**What you see.** A successful write with no bytes dropped, and a page that visually collapses from its real multi-column layout into a single stacked column. It fires on any `update_element` or `update_module` call that resolves by something other than `id`.
+
+**Status.** Fixed in 7.5.29. Root-capable nodes pass through the top level unchanged, and only genuine leaf modules get bundled into their own container.
+
+**What to do.** Restore the snapshot taken before the write. The layout data was never lost, so a restore recovers it exactly.
+
+### An edit that landed in the database and stayed invisible
+
+**What goes wrong.** Two separate cache faults. On hosts with a persistent object cache (Pressable, WP Engine, Redis), a write to a text or HTML element on a large page reached the database while the cached copy the site kept serving stayed stale. Separately, Beaver keeps a static digest of the layout that its own editor refreshes when a human clicks Publish, and Respira's writes bypassed that refresh, so approved content could render partially or stay stale even though the data was correct.
+
+**What you see.** The change is correct in Respira and in the database, and the page keeps showing the old version until you open Beaver and publish by hand.
+
+**Status.** The object cache half fixed in 7.5.34: the generic write paths now force the write and bust the meta cache. The digest half fixed in 7.5.32: every Beaver write path refreshes the digest the way Beaver's own editor does.
+
+**What to do.** On an older build, open the page in Beaver and publish once. No data is at risk in either case.
+
+### Payload wrappers that quietly became empty stub modules
+
+**What goes wrong.** Beaver's normalizer did not recognise every documented wrapper shape. A `{"rows": [...]}` payload nested one level inside a list, which happens naturally on any `mode: "append"` call because the merge step listifies it, and a `{content: [...]}` envelope sent by hosted clients both persisted a row, column-group, column and anonymous module stub.
+
+**What you see.** `success: true` echoing the original element count, and modules whose settings read `{"type":"module"}` with the heading or button text and links gone.
+
+**Status.** Fixed in 7.5.49 and 7.5.56. The normalizer now recursively unwraps every documented content envelope, an unknown non-empty wrapper returns an actionable 422 without touching the page, and injection verifies the exact native node graph after saving so a database or object cache failure cannot produce another false positive.
+
+**What to do.** Nothing on 7.5.56 or later.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Beaver stores its page data in post meta (`_fl_builder_data`), not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Content updates** - Change text, links, and images without opening the builder

--- a/builders/breakdance.mdx
+++ b/builders/breakdance.mdx
@@ -167,6 +167,60 @@ If you corrupt `_breakdance_data` or remove required elements, the Breakdance ed
 
 </Callout>
 
+## Write hazards
+
+Reproduced ways a Breakdance write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### Every edit on the site refused with "not registered on this site"
+
+**What goes wrong.** The write path guard checked whether an element type was a real PHP class. Breakdance registers its elements as editor definitions, not autoloadable classes, so the standard `EssentialElements\Section` container and everything built on it looked unregistered.
+
+**What you see.** On Breakdance 2.8.0, every `update_element` and `apply_builder_patch` call failing with `Unknown Breakdance element type EssentialElements\Section, not registered on this site`. Every change on the site blocked.
+
+**Status.** Fixed in 7.5.3. The guard now checks the same element catalog the read side uses, so reads and writes agree.
+
+**What to do.** Update to 7.5.3 or later. This one at least failed loudly, which is the reason it was found in a day rather than a month.
+
+### A write that landed in a dead key and reported a real hash change
+
+**What goes wrong.** The write path decided where to store new content by matching the element's stored type name against a list of fully qualified class names. Any element whose stored type was still a bare legacy string, which happens on older Breakdance content and on beta builds, missed that match and was written to a decoy key nothing reads.
+
+**What you see.** `update_element` reporting success with a genuine hash change, because the decoy write was real bytes. The page just never shows them. This is the hardest shape to catch, because even the no-op detector agrees something moved.
+
+**Status.** Fixed in 8.6.3. When the type name does not match, the write now trusts the already-persisted attribute shape instead, so it lands on the field Breakdance's own renderer reads. Reproduced broken and then reproduced fixed on the same page and element.
+
+**What to do.** If a Breakdance edit reported a hash change and still did not show, extract the element and look at which key the new value ended up in.
+
+### A code block that stored correctly and rendered nothing
+
+**What goes wrong.** Code passed to an `EssentialElements\CodeBlock` was stored under the agent's vocabulary key (`code`, `html`, `js` or `css`), which Breakdance never reads. Its renderer reads `php_code`, `css_code` and `js_code`.
+
+**What you see.** A structurally valid block that passes the validator and renders nothing on the page.
+
+**Status.** Fixed in 7.4.25 across all three write paths, live-verified on the Breakdance test environment.
+
+**What to do.** Nothing on 7.4.25 or later. On an older build, pass the native `php_code`, `css_code` and `js_code` field names.
+
+### `build_page` writing elements with empty properties
+
+**What goes wrong.** The complexifier read content only from `attributes`, which is the shape `extract_builder_content` produces. A `build_page` caller has no extract to copy from, so an agent naturally invents the near-native `{type, data: {content: {...}}}` shape instead, and that shape produced an empty `properties` object on every element.
+
+**What you see.** A page built with the right number of elements, all of them empty.
+
+**Status.** Fixed in 7.0.20. Six payload shapes are now accepted in priority order, and the element type is read from `data.type` when it is not at the item root.
+
+**What to do.** Nothing on 7.0.20 or later.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Breakdance stores its page data in `_breakdance_data` post meta, not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## See also
 
 Use these tools with Breakdance pages:

--- a/builders/bricks.mdx
+++ b/builders/bricks.mdx
@@ -262,6 +262,60 @@ Bricks global elements and templates are accessible through Respira:
 
 ---
 
+## Write hazards
+
+Reproduced ways a Bricks write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### Patches aimed at an element id changed nothing and reported success
+
+**What goes wrong.** The Bricks adapter never declared which key holds its element data. Bricks nodes carry their editable values under `settings`, but the adapter inherited the interface default of `attributes`, so the shared patcher merged updates into a key Bricks does not read. Every id-targeted `apply_builder_patch` call took that generic route.
+
+**What you see.** Either `respira_patch_not_persisted`, when the round trip happened to be byte-stable, or a plain `success: true` with nothing changed, when an unrelated normalization moved the storage signature and fooled the no-op guard. Path-based targeting worked, which is what made it look like ids specifically were broken.
+
+**Status.** Fixed in 8.6.28. Bricks now declares its real bucket, and the patcher accepts an update wrapped in that key without double-nesting it.
+
+**What to do.** On an older build, target by path instead of by id. On 8.6.28 or later, either works.
+
+### Typography values stored under a name Bricks never reads
+
+**What goes wrong.** Bricks renders from kebab-case typography names such as `font-size`. A camelCase spelling like `fontSize` used to be stored verbatim alongside the canonical one, the canonical one kept winning, and the tool reported success for a change that was never going to show. This applied both at the settings root and nested inside `_typography`.
+
+**What you see.** A successful write, and the front end still at the old size or weight. Nothing in the response points at the key name.
+
+**Status.** Fixed in 8.6.28. Known camelCase names now fold into their canonical form. A name that is neither canonical nor a known alias is refused on a fresh write with `respira_invalid_typography_key` (422), and stripped with a warning on a round trip, rather than being stored where it will never be read.
+
+**What to do.** Prefer the kebab-case names Bricks itself uses. If a write comes back with `respira_invalid_typography_key`, the error names the key it would not store.
+
+### Custom CSS saved, and the front end kept serving the old stylesheet
+
+**What goes wrong.** A per-element style write regenerated the page's CSS file but never told Bricks the file was new. Every global Bricks style write has always bumped the cache markers; the per-element path never did, so visitors kept getting the previous timestamp and the previous inline-CSS transient.
+
+**What you see.** The rules are in the element in the builder, and the browser serves the old stylesheet. Adding the identical rules as an inline `style` block appears instantly, because that route never touches Bricks' CSS pipeline at all. That contrast is the tell.
+
+**Status.** Fixed in 8.6.28. The markers are bumped after a write that actually changed a style, and only then, because the marker is site-wide and a text edit cannot alter generated CSS.
+
+**What to do.** On an older build, save any global Bricks style to force the markers forward. On 8.6.28 or later, nothing.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Bricks stores its page data in post meta (`_bricks_page_content_2`), not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
+### An element arriving in Bricks that was meant for another builder
+
+**What goes wrong.** On a site running Bricks alongside the block editor, a page whose last block had just been removed reads as having no builder, so the check fell back to asking the site, which prefers any other active builder over Gutenberg. `add_text` then wrote a real, verified Bricks element into Bricks storage on a page that was supposed to be a block page.
+
+**What you see.** A successful write with a real element id, and an element that is invisible to every block-editor read of that page.
+
+**Status.** Fixed in 8.6.28 for the duplicate case: when the target is a Respira duplicate, the builder is resolved from the original it was copied from, which still has its content, instead of guessing from the site. See the [Gutenberg page](/builders/gutenberg#write-hazards) for the full entry.
+
+**What to do.** On a mixed-builder site, avoid writing to a page you have just emptied. Add content back through the builder that owns the page first, so detection has something to read.
+
 ## See Also
 
 - [`respira_find_element`](/tools/element-ops/find-element) — Find elements by content, type, or class

--- a/builders/brizy.mdx
+++ b/builders/brizy.mdx
@@ -148,6 +148,40 @@ Brizy Pro features and cloud-synced templates work with Respira:
 - **Brizy Cloud**: Cloud-synced templates need the Brizy interface for sync operations
 - **Custom CSS**: Per-element CSS is preserved; complex styling changes may need the builder
 
+## Write hazards
+
+Reproduced ways a Brizy write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### Every Brizy edit reporting `write_was_noop: true`
+
+**What goes wrong.** The no-op detector compares a signature of the builder's storage before and after the write. Brizy's `brizy` meta holds a serialized array, and the signature was reading it as a string, which produces the literal text `Array` on every read. Five bytes, identical every time, so the before and after signatures always matched.
+
+**What you see.** Every Brizy edit reporting `write_was_noop: true` and `bytes_changed: 0`, even though it persisted and rendered correctly. Agents read that as a silent failure and retried in the same session.
+
+**Status.** Fixed in 7.4.25. The signature now serializes Brizy's decoded editor tree, which is the thing writes actually mutate. This was a diagnostics fault only. Brizy writes were never broken.
+
+**What to do.** On 7.4.25 or later, trust the field. If you are seeing it on an older build, check the page before assuming the write failed.
+
+### The front-end compile step depends on a service outside your site
+
+**What goes wrong.** Nothing in Respira. Brizy compiles its front-end output through its own compiler service, so a site with no outbound internet access can hold a correct, editor-openable page that never compiles for visitors.
+
+**What you see.** The Brizy editor opens the page and shows your change. The front end does not.
+
+**Status.** Not a defect, and not fixable from Respira's side. Brizy moved from read to write in 7.4.0 "Clearing" with this caveat stated at the time.
+
+**What to do.** Open and save the page in the Brizy editor once to trigger the compile, and check the site can reach Brizy's service.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Brizy stores its page data in post meta, not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Quick content updates** - Change text, buttons, and links without the builder

--- a/builders/divi-5.mdx
+++ b/builders/divi-5.mdx
@@ -408,6 +408,30 @@ All `divi/*` modules accept a `settings` object with shorthand keys. Respira map
 
 ---
 
+## Write hazards
+
+Reproduced ways a Divi 5 write has gone wrong. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder, and the [Divi page](/builders/divi#write-hazards) for the Divi 4 hazards.
+
+### Divi 5 markup on a post or a custom post type rendered with the Divi 4 renderer
+
+**What goes wrong.** Writing `divi/*` block markup to a post requires flipping the site into Divi 5 mode in the same request, otherwise valid block markup renders through the wrong renderer. 8.6.3 fixed that for pages. Pages, posts and custom post types are three parallel implementations in the plugin, and the fix landed on one of them.
+
+**What you see.** Correct data stored, wrong renderer chosen, and a post or a custom post type entry that cannot be corrected by clearing any cache. Hand-authored Divi 5 markup pushed to a page worked; the identical markup pushed to a post did not.
+
+**Status.** Fixed in 8.6.28. All three paths now flip the mode, and the test asserts all three call sites rather than only that the helper works. Two internal guards that would have let the fix die silently under a rename were removed at the same time.
+
+**What to do.** Update to 8.6.28 or later, then rewrite the affected post. Clearing caches will not help, because the stored data was never the problem.
+
+### The empty-inject guard, and the one case where it fired wrongly
+
+**What goes wrong.** Nothing, usually. `respira_divi5_empty_inject_blocked` is a deliberate refusal: it stops a write that would overwrite an existing Divi 5 layout with empty or placeholder-only content. It has fired wrongly exactly twice, and both times the cause was upstream of the guard.
+
+**What you see.** "Refusing to overwrite existing Divi 5 layout with empty/placeholder-only content" on a write whose payload plainly had content in it.
+
+**Status.** Two causes, both fixed. In 6.6.9 a payload using shorthand type names (`heading`, `section`, `row`, `column` without the `divi/` prefix) was rejected by three pipeline stages that still matched on the raw prefix before the normalizer ran. In 8.6.31 a legacy Divi 4 shortcode page on a Divi 5 site was misrouted into the Divi 5 writer, which then correctly counted zero Divi 5 layout nodes and correctly refused; see the [Divi page](/builders/divi#write-hazards) for that one. The guard itself was right in both cases and has not been loosened.
+
+**What to do.** On 8.6.31 or later, treat this error as genuine: the page really does have a Divi 5 layout and your payload really did not carry layout content. Extract the page and compare before resending.
+
 ## Recent capabilities (plugin v7.5.x)
 
 - **Native, editable module builds across a 108-module catalog.** `build_page` writes real `divi/*` modules from the catalog, discoverable through `get_builder_inline_schemas`, instead of falling back to a raw code block.

--- a/builders/divi.mdx
+++ b/builders/divi.mdx
@@ -146,6 +146,44 @@ Global layout writes are still snapshotted and reversible. If a confirmed write 
 - Dynamic content tokens are preserved but not directly editable
 - Theme Builder global layouts are written live behind a confirmation handshake, not staged for approval
 
+## Write hazards
+
+Reproduced ways a Divi write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the general picture and the guards that apply to every builder.
+
+### A Divi 4 page on a Divi 5 site read as one opaque block
+
+**What goes wrong.** A Divi 5 site can still hold pages that were never migrated: their `post_content` is plain `[et_pb_*]` shortcodes, often inside a classic block wrapper. Until 8.6.31, every Divi routing decision asked the site's runtime rather than the page in front of it. So a legacy shortcode page on a Divi 5 site was sent down the Divi 5 branch, where block parsing collapses classic content into a single untyped node that surfaces as one `core/freeform` wrapper. The whole page arrived as one opaque block.
+
+**What you see.** Two symptoms from one misroute. `update_module` answers `respira_module_not_found`, "No module found with type et_pb_text", for a text module that is plainly on the page. `update_element` gets as far as the Divi 5 writer, which counts zero layout nodes and refuses with `respira_divi5_empty_inject_blocked`, "Refusing to overwrite existing Divi 5 layout with empty/placeholder-only content". The guard was right. The page was never Divi 5.
+
+**Status.** Fixed in 8.6.31. Routing is decided by the page's own content. The Divi 5 empty-inject guard is untouched and still refuses a genuine Divi 5 page.
+
+**What to do.** Update to 8.6.31 or later. On an older build there is no workaround from the agent side, because nothing in the response tells you the page was misrouted.
+
+### A 16-element page written as one empty section
+
+**What goes wrong.** A payload that describes children with the vocabulary aliases `rows`, `cols`, `columns`, `modules`, `elements` or `innerBlocks` instead of the canonical `children` used to be counted one way and emitted another. The element counter walked the aliases and saw everything; the Divi 4 shortcode emitter read only `children` and dropped the lot.
+
+**What you see.** `success: true` with a full `element_count`, and a page that renders as a single empty `[et_pb_section]`. `update_module` can then never find the modules that were reportedly built.
+
+**Status.** Fixed in 7.5.16. Divi 4 now runs the same deep alias fold Divi 5 has had since 7.0.32, including aliases nested under canonical `children`. A children-dropped write now fails loudly with `respira_children_dropped` and writes nothing, so a caller cannot be told 16 elements were written when zero were.
+
+**What to do.** Nothing, if you are on 7.5.16 or later. If you do see `respira_children_dropped`, that is the guard working: nothing was written, and the response names the counts that disagreed.
+
+### An edit landing on the wrong module
+
+**What goes wrong.** Divi 4 shortcodes carry no stable element IDs unless you set one, so targeting is by type, admin label, path or matched content. Before 8.6.28, `find_element` honoured `match_content` and returned the module you meant, then `update_element` and `remove_element` re-resolved the identifier from scratch without it and acted on the first module of that type on the page.
+
+**What you see.** A search that correctly found the third text module, followed by an edit to the first. The reporter of this one had to restore a snapshot.
+
+**Status.** Fixed in 8.6.28. Both tools now accept and honour `match_content`, and a genuinely ambiguous target is refused with `respira_ambiguous_target` and the list of candidates rather than guessed at. `on_ambiguous_match: "first"` opts back in to the old behaviour explicitly.
+
+**What to do.** Give important modules an admin label. A label is the only stable handle a Divi 4 page has, and it turns an ambiguous target into an exact one.
+
+### An Oxygen-shaped patch landing in a dead key
+
+Not a Divi hazard: Divi's attribute bucket is `attributes`, which is the name the shared update path already treated as correct, so Divi was never affected by the key-fold problem described on the [Gutenberg](/builders/gutenberg#write-hazards) and [Oxygen](/builders/oxygen#write-hazards) pages. Recorded here only so you do not go looking for it.
+
 ## Recent capabilities (8.0 "Canopy")
 
 Two fixes from auditing the safety layer itself, both on the Divi path:

--- a/builders/elementor.mdx
+++ b/builders/elementor.mdx
@@ -131,6 +131,46 @@ Elementor Pro's Theme Builder templates (headers, footers, single post templates
 - **Dynamic tags**: Elementor dynamic content tokens are preserved but not directly editable
 - **Third-party widgets**: Support varies by add-on; core Elementor widgets have full support
 
+## Write hazards
+
+Reproduced ways an Elementor write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### Widgets stored with no type, which took the whole page down
+
+<Callout kind="danger">
+
+This is the worst thing Respira has done to an Elementor site. It broke the front end, and the write reported success with a green render check three times in a row.
+
+</Callout>
+
+**What goes wrong.** A tree that mixed simplified `type: "container"` wrappers at the top with Elementor's native `widgetType` spelling on the widgets underneath skipped the normalizing pass, because that pass only ran when the first top level node was itself in native shape. The emitter then wrote `elType: widget` with no `widgetType` key at all. Elementor cannot instantiate that: the missing key makes its element factory return the whole widget-type map instead of one type, and the next call fatals on an array.
+
+**What you see.** "There has been a critical error on this website" on the front end. Empty containers in the editor. Reading the page back shows `"widget": null` for every widget. Re-injecting identical content changes nothing, and the rendered hash is identical across the blank page and every payload you try, because the fatal always renders the same error page. The same JSON shape works on other pages in the same session, which is what makes it look random. It was never the size or the depth of the tree. It was whether the first top level node happened to be in native shape.
+
+**Status.** Fixed in two halves. 8.6.28 fixed the emitter: it now understands both spellings, and a widget that still resolves to no type aborts the write instead of persisting a page that cannot render. 8.6.31 fixed the validator, which had been standing next to the corruption unable to see it. The shape check asserted only that the data decoded to an array with enough top level entries, so a tree whose every widget had lost its type passed completely. It now walks the persisted tree and fails with `elementor_widget_missing_type`, naming the path and the node. The one Elementor write path that bypasses the emitter, used by `make_responsive`, now refuses the same shape before touching the database, so a page already damaged this way cannot have the damage rewritten by a later edit.
+
+**What to do.** If a page is already in this state, a targeted edit will correctly refuse to touch it. Recover with a fresh replace-mode write of the whole page, or restore a snapshot. Update to 8.6.31 or later first, or the recovery write can reproduce the damage.
+
+### An `attributes` patch merged onto the element root
+
+**What goes wrong.** Elementor's attribute bucket is called `settings`. The shared update path treated a payload key named `attributes` as already being in the right place, which is true only for builders whose bucket is literally called that. On Elementor v3 widgets the patch was merged onto the element root, where the serializer never looks.
+
+**What you see.** `write_was_noop: true` on a response that otherwise reads as successful, and a page that comes back byte-identical. Content updates on the same widget work, which is what makes it look like a per-widget or per-setting problem. It never was.
+
+**Status.** Fixed in 8.6.28. The same change fixed the Gutenberg family and Oxygen Classic, which had the same fault for the same reason.
+
+**What to do.** Read `write_was_noop`. On any Respira version, that field is the tell that a write reported success and moved nothing.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Elementor stores its page data in post meta (`_elementor_data`), not in the post body. A duplicate's baseline snapshot used to be captured before the meta was copied onto the new post, so builder detection looked at a post with no builder data yet, found none, and stored an envelope containing the hash of an empty payload.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. The snapshot is taken after the meta copy, and restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Duplicates created before 8.6.28 keep their empty baseline. Re-duplicate anything you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Quick content updates** - Change headlines, button text, or links without opening the builder

--- a/builders/flatsome.mdx
+++ b/builders/flatsome.mdx
@@ -114,5 +114,35 @@ Respira includes a Flatsome Intelligence package with:
 
 When using `build_page`, bare elements (not wrapped in section > row > col) are automatically wrapped in a full container hierarchy. You can pass a flat list of elements and Respira will create the correct structure.
 
+## Write hazards
+
+Reproduced ways a Flatsome write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### An edit landing on the wrong element
+
+**What goes wrong.** Flatsome shortcodes carry no stable element IDs, so targeting is by type, class, path or matched content. Before 8.6.28, `find_element` honoured `match_content` and returned the element you meant, then `update_element` and `remove_element` re-resolved the identifier from scratch without it and acted on the first element of that type on the page.
+
+**What you see.** A search that correctly found the third text box, followed by an edit to the first.
+
+**Status.** Fixed in 8.6.28. Both tools accept and honour `match_content`, and a genuinely ambiguous target is refused with `respira_ambiguous_target` and the list of candidates. `on_ambiguous_match: "first"` opts back in to the old behaviour explicitly.
+
+**What to do.** Put a distinct `class` on elements you edit often. It is the most stable handle a shortcode page has.
+
+### `duplicate_element` unusable on this builder
+
+**What goes wrong.** The MCP tool exposed a single `element_id` argument while the plugin route has always required `identifier_type` and `identifier_value`. On builders with no stable IDs anywhere, there was no workaround.
+
+**What you see.** "Missing parameter(s): identifier_type, identifier_value" on every duplicate call.
+
+**Status.** Fixed in MCP server 6.19.7. Note this is the MCP server version, not the plugin version.
+
+**What to do.** Update the MCP server as well as the plugin.
+
+### Two hazards Flatsome does not have
+
+Recorded so you do not go looking for them. Flatsome stores its content as shortcodes in the post body, so the empty-baseline snapshot problem described on the [overview page](/builders/overview#write-hazards) never affected it: a duplicate's content is copied by the post insert itself. Flatsome's attribute bucket is called `attributes`, which is the name the shared update path already treated as correct, so the key-fold problem that hit the block family and Oxygen Classic never applied here either.
+
+
+
 
 {/* bust build cache 2026-05-06 */}

--- a/builders/generateblocks.mdx
+++ b/builders/generateblocks.mdx
@@ -38,6 +38,30 @@ Prime once at the start of a session so the agent builds and edits in blocks, no
 
 The workflow is the same as core Gutenberg because GenerateBlocks are namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
 
+## Write hazards
+
+GenerateBlocks are namespaced WordPress blocks, so every hazard in the [Gutenberg write hazards](/builders/gutenberg#write-hazards) section applies here unchanged. The one worth knowing by heart:
+
+### An `attributes` patch merged onto the block root
+
+**What goes wrong.** A block's attribute bag is called `attrs` in the stored markup. The shared update path treated a payload key named `attributes` as already being in the right place, which is true only for builders whose bucket is literally called that. The patch was merged onto the block root, where the serializer never looks. `attributes` is the vocabulary the WordPress block API itself teaches, so it is the natural thing to write.
+
+**What you see.** `write_was_noop: true` on a response that otherwise reads as successful, and a page that comes back byte-identical. Content updates on the same block worked, which is what made it look like a per-block problem.
+
+**Status.** Fixed in 8.6.28, for every builder that inherits the block path.
+
+**What to do.** Read `write_was_noop` on every write. On any version, that field is the tell that a write reported success and moved nothing.
+
+### The intelligence layer reporting as unavailable
+
+**What goes wrong.** The check that reports whether a builder has an intelligence package derived the package directory from the builder's display name, so the block-vendor builders went looking for directories that do not and should not exist. The block package reads the live block registry, so it already covered every block these builders register.
+
+**What you see.** The builder info screen reporting no intelligence layer for GenerateBlocks. Cosmetic: the capability was there the whole time.
+
+**Status.** Fixed in 8.2.1 for GenerateBlocks, Spectra, Kadence Blocks and GreenShift by inheritance.
+
+**What to do.** Nothing.
+
 ## FAQ
 
 ### Does Respira edit GenerateBlocks natively or convert them?

--- a/builders/gutenberg.mdx
+++ b/builders/gutenberg.mdx
@@ -171,6 +171,40 @@ See [Site Editor (Full Site Editing)](/builders/site-editor) for the tools, the 
 - **Interactive blocks**: Blocks with complex interactivity (forms, carousels) may need manual editing
 - **Site-level structural writes are beta-gated per site and off by default**: read-only discovery of templates, patterns, navigation and global styles is available everywhere
 
+## Write hazards
+
+Reproduced ways a block write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder. These entries also cover the block-vendor builders that inherit this path: [Spectra](/builders/spectra), [Kadence Blocks](/builders/kadence-blocks) and [GenerateBlocks](/builders/generateblocks).
+
+### An `attributes` patch merged onto the block root
+
+**What goes wrong.** A block's attribute bag is called `attrs` in the stored markup. The shared update path treated a payload key named `attributes` as already being in the right place, which is true for the builders whose bucket is literally called that and wrong for the whole block family. `attributes` is also the vocabulary the WordPress block API itself teaches, so it is the natural thing to write. The patch was merged onto the block root, where the serializer never looks.
+
+**What you see.** `write_was_noop: true` on a response that otherwise reads as successful, and a page that comes back byte-identical. Confirmed independently for a Kadence image `alt` (a plain string) and a Rank Math FAQ block's `questions` (an array of objects), so both scalar and structured shapes were affected. Content updates on the same block worked, which is what made it look like a per-block problem. It was never per-block.
+
+**Status.** Fixed in 8.6.28. The same change fixed Oxygen Classic, whose bucket is `options`, and Elementor v3 widgets, whose bucket is `settings`.
+
+**What to do.** Read `write_was_noop`. On any Respira version, that field is the tell that a write reported success and moved nothing. On 8.6.28 or later, `attributes` and `attrs` both land in the right place.
+
+### A paragraph added to a block page written into a different builder entirely
+
+**What goes wrong.** On a page whose last block had just been removed, the content is empty, so the per-page builder check correctly reported nothing and the fallback asked the site instead. The site-level check prefers any other active builder over the block editor. On a site running Bricks alongside blocks, `add_text` then wrote a real, verified Bricks element into Bricks storage.
+
+**What you see.** A successful write with a real element id, and content that is invisible to every block-editor read of that page. The write genuinely persisted, which is exactly why it reported success. It just persisted somewhere you were not looking.
+
+**Status.** Fixed in 8.6.28 for the duplicate case: when the target is a Respira duplicate, the builder is resolved from the original it was copied from, which still has its content, instead of guessing from the site.
+
+**What to do.** On a mixed-builder site, do not write to a page you have just emptied. Put a block back first, so detection has something to read, or check `respira_get_builder_info` for that page before writing.
+
+### A page's template deleted by an edit that only touched its SEO description
+
+**What goes wrong.** A safety check clears a page template the active theme does not recognise, but the lookup it used only sees templates registered through hooks meant for the classic wp-admin screen. A REST call never fires those hooks, so a genuinely valid builder template looked unregistered and was wiped on the very next meta-only edit.
+
+**What you see.** A duplicate that throws "invalid page template" when you try to approve it, after an edit that had nothing to do with templates.
+
+**Status.** Fixed in 8.6.28. The check no longer runs during a REST request.
+
+**What to do.** Re-set the template on any page this happened to. It is a stored value, so once put back it stays.
+
 ## When to Use This Tool
 
 - **Before publishing** - Review and fix content before going live

--- a/builders/kadence-blocks.mdx
+++ b/builders/kadence-blocks.mdx
@@ -42,6 +42,30 @@ Prime once at the start of a session so the agent builds and edits in blocks, no
 
 The workflow is the same as core Gutenberg because Kadence blocks are namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
 
+## Write hazards
+
+Kadence Blocks are namespaced WordPress blocks, so every hazard on the [Gutenberg write hazards](/builders/gutenberg#write-hazards) section applies here unchanged. One of them was reported on a Kadence block, so it is worth naming in full.
+
+### An `attributes` patch merged onto the block root
+
+**What goes wrong.** A block's attribute bag is called `attrs` in the stored markup. The shared update path treated a payload key named `attributes` as already being in the right place, which is true only for builders whose bucket is literally called that. The patch was merged onto the block root, where the serializer never looks. `attributes` is the vocabulary the WordPress block API itself teaches, so it is the natural thing to write.
+
+**What you see.** `write_was_noop: true` on a response that otherwise reads as successful, and a page that comes back byte-identical. Confirmed on a `kadence/image` `alt` value, a plain string, and independently on a Rank Math FAQ block's `questions`, an array of objects. Content updates on the same block worked, which is what made it look like a per-block problem. It never was.
+
+**Status.** Fixed in 8.6.28.
+
+**What to do.** Read `write_was_noop` on every write. On any version, that field is the tell that a write reported success and moved nothing.
+
+### A leftover option from another builder claiming your site
+
+**What goes wrong.** Builder detection used to trust a `_fl_builder_version` option that Beaver Builder does not remove when it is uninstalled. A Kadence site that had once had Beaver Builder, or inherited its data through a migration, was reported as a Beaver site.
+
+**What you see.** `respira_get_builder_info` naming the wrong builder, and block tools that do not behave the way a block site should.
+
+**Status.** Fixed in 7.5.31. The detector no longer trusts that leftover option.
+
+**What to do.** If detection names a builder that is not installed, check `respira_get_builder_info` for the page as well as the site.
+
 ## FAQ
 
 ### Does Respira edit Kadence blocks natively or convert them?

--- a/builders/overview.mdx
+++ b/builders/overview.mdx
@@ -67,6 +67,45 @@ Sites running the Newspaper or Newsmag theme with TagDiv Composer are detected a
 3. **Update**: Changes are applied to just that module
 4. **Preserve**: All other content, styling, and settings remain intact
 
+## Write hazards
+
+Respira writes to live sites, and some of those writes have gone wrong. This section says what a write hazard is, how each class is guarded against today, and where the per-builder list lives. Every builder page carries its own **Write hazards** section with the reproduced cases for that builder.
+
+### What a write hazard is
+
+A write hazard is a write that reports success it has not earned. It comes in three shapes:
+
+1. **Silent no-op.** The tool answers success and the stored page is byte-identical. Almost always the value was merged into a key the builder never reads.
+2. **Wrong target.** The write really persists, but into a different element, a different page, or a different builder than the one you meant.
+3. **Damaging write.** The write persists a shape the builder cannot render, and the page breaks.
+
+The first two are worse than an outright error, because nothing tells you to go and look. A hazard with no visible symptom is the one that costs you a week.
+
+### The four guards, and why each exists
+
+<Callout kind="alert">
+
+Every guard below was added after it was found missing. None of them was designed in advance. i would rather write that down than let the list read like a feature tour.
+
+</Callout>
+
+**Duplicate-first.** With direct editing turned off, an edit goes to a duplicate of the page and waits for your approval, so the live page is never the thing being experimented on. In 8.6.28 this was found to be leaking: all 27 `add_*` widget shortcuts wrote straight to the live published page without ever reading the setting, while `update_element` and `inject_builder_content` honoured it correctly. All 27 now route through the same gate.
+
+**Snapshots.** Every write records a before state you can restore from the Changes screen in wp-admin. In 8.6.28 a duplicate's baseline snapshot was found to have been captured before the page meta was copied across, so for every builder that stores its content in post meta the baseline recorded an empty page. Restoring one could never bring the content back, and reported success anyway. The snapshot is now taken after the meta copy, and restoring a snapshot that recorded no builder payload onto a page that currently has content is refused with `respira_snapshot_stale_empty_baseline` instead of quietly doing nothing. Duplicates created before 8.6.28 keep their empty baseline, so re-duplicate anything you rely on for rollback.
+
+**Render validation.** After a write, the page is fetched and checked. Until 8.6.28 that check asked for headers only and passed on any 2xx. WordPress sends the 200 before it renders the body, so a fatal raised part way through rendering leaves the 200 already on the wire and a page reading "There has been a critical error on this website" passed every time. The check now reads the body and looks for the markup WordPress' own error document hardcodes, which is markup rather than translated text, so it holds in any language. A page that cannot be fetched at all is reported as unchecked, not as broken.
+
+**Refusal over guessing.** When a target is genuinely ambiguous, the tool refuses with `respira_ambiguous_target` and lists the candidates rather than picking one. Before 8.6.28, `update_element` and `remove_element` re-resolved the identifier from scratch and acted on the first element of that type on the page, so a search that correctly found the third paragraph was followed by an edit to the first. If you want the old behaviour, `on_ambiguous_match: "first"` asks for it explicitly.
+
+**Write receipts.** Every major write carries a `write_receipt` with `changed`, a before and after fingerprint, and a `covers` field. Read the `covers` field. The fingerprint hashes the post content, the builder payload and an allowlisted set of post meta. It is not total: meta outside that allowlist, taxonomy terms and comment counts are not in it. In 8.6.31 the allowlisted meta was added after an SEO title edit that genuinely persisted came back reported as `changed: false`. A receipt is proof about what it names and silent about the rest.
+
+### What this means for you
+
+- **Keep the plugin current.** Nearly every hazard on these pages is fixed, and a fix only reaches a site that updates. Note that 8.6.27 exists as a tag with no release behind it and never reached a single site, so 8.6.28 is the first build after 8.6.26 the updater could serve.
+- **Read the response, not just the success flag.** `write_was_noop: true`, a `warnings` array, `partial_write: true` and `agent_must_not_retry: true` all mean something did not go the way the word "success" suggests.
+- **Do not blind-retry a write that reported success.** If the page did not change, resending the same payload will not change it either. Extract the page and look at what actually got stored.
+- **Report anything that looks like a silent success.** Almost every entry on these pages exists because somebody noticed their page had not changed and said so. i would rather chase a false alarm than not hear about a real one.
+
 ## Key Tools
 
 - `respira_get_builder_info` — detect active builder, version, module count

--- a/builders/oxygen.mdx
+++ b/builders/oxygen.mdx
@@ -143,6 +143,70 @@ Oxygen can include Gutenberg blocks via Inner Content. Respira can edit both the
 - **Global styles**: Oxygen's global colors and stylesheets need the builder interface
 - **Custom PHP**: Code blocks with PHP are preserved but not editable through Respira
 
+## Write hazards
+
+Reproduced ways an Oxygen write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder. Oxygen Classic and Oxygen 6 store data differently, so most entries name which one they apply to.
+
+### Oxygen Classic: a flat patch landing in a key Oxygen never reads
+
+**What goes wrong.** Oxygen Classic's attribute bucket is `options`. Two separate versions of this fault existed. Before 7.0.40, a flat patch such as `update_element({type: ct_headline, updates: {ct_content: "new"}})` was wrapped into a hardcoded `settings` bucket that Oxygen's complexifier reads never. Before 8.6.28, a payload that explicitly used the key `attributes` was treated as already structural and merged onto the element root instead of into `options`.
+
+**What you see.** `success: true` with the persisted element unchanged, and the page still rendering the old value. On the 8.6.28 shape you also get `write_was_noop: true`, which is the only field that gives it away.
+
+**Status.** The first half fixed in 7.0.40, which picks the wrap target by looking at the shape of the existing element. The second half fixed in 8.6.28, which was the same change that fixed the block family and Elementor v3.
+
+**What to do.** Read `write_was_noop` on every write. If it is true, the write moved nothing regardless of what the success flag says.
+
+### Oxygen Classic: an image update landing next to the value the renderer reads
+
+**What goes wrong.** Oxygen Classic 4.8 and later store image `src`, `alt`, `width` and `height` under `options.original.*`, not at `options.*`. A flat patch was correctly wrapped into `options` and then deep-merged, which produced `options.src` as a sibling of `options.original` while `options.original.src` stayed at the old value.
+
+**What you see.** A successful write, an internally inconsistent stored shape, and the page still rendering the old image.
+
+**Status.** Fixed in 7.0.51 for `ct_image` and `ct_image_overlay`. An explicit `{original: {src: "..."}}` patch has always passed through untouched, and still wins.
+
+**What to do.** Nothing on 7.0.51 or later. On an older build, pass the explicit `original` shape.
+
+### Oxygen Classic: style writes to global templates that persisted nowhere
+
+**What goes wrong.** The same lift that nests style properties under `options.original` only ever covered image elements. Sections, divs, headlines and anything inside a `ct_template`, such as a global footer, had their style writes land as dead sibling keys.
+
+**What you see.** `color`, `background-color` and similar writes reporting success, with nothing changed on the live page.
+
+**Status.** Fixed in 8.1.1. The lift now covers every element type.
+
+**What to do.** Re-apply any global template styling written before 8.1.1. It was never stored where the renderer looks, so it is not recoverable from a snapshot either.
+
+### Oxygen 6: rich pages collapsing to a handful of basic elements
+
+**What goes wrong.** Oxygen 6 ships its core elements in the `OxygenElements` namespace. The rich `EssentialElements` blocks (Section, Heading, Button and the rest) are registered too, but only when the common "Breakdance Elements for Oxygen" add-on is installed. Respira used to assume they were never registered.
+
+**What you see.** Flat, generic pages. A heading comes out as plain text, a button as a plain link, a section as a bare container. Agents then compensate by dumping the whole design into one raw HTML block, which is worse.
+
+**Status.** Fixed in 7.4.8. The add-on is detected and the real native elements are emitted. Sites without the add-on keep the safe core-only mapping, which is the correct behaviour there.
+
+**What to do.** If your Oxygen 6 pages look basic, check whether the add-on is installed and whether you are on 7.4.8 or later.
+
+### Oxygen 6: design edits to an already-built element dropping everything but colour
+
+**What goes wrong.** `update_element` takes a nested `design` bucket (`design.typography.fontSize`, `design.spacing.margin` and so on), but the translation into Oxygen 6's real control paths only scanned flat top level keys, which is the shape `build_page` and the `add_*` shortcuts use. A `design` bucket edit fell through untranslated and landed at a dead sibling of the real property path. `color` happened to share the same shallow path both ways, which is why it alone appeared to work.
+
+**What you see.** A design edit that reports success, with only the colour actually changing. A related corruption in the same code wrote the literal text `Array` into stored CSS values when a caller passed back the `{value, unit}` object that `extract_builder_content` itself echoes.
+
+**Status.** Fixed in 7.5.48, live-verified against Oxygen 6.0.0.
+
+**What to do.** Note one genuine platform limit that no plugin can work around: `OxygenElements\Container` has no design or CSS support in Oxygen 6 itself. Use `EssentialElements\Div` where you need a design-capable wrapper.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Oxygen stores its page data in post meta, not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Quick content updates** - Change headlines, button text, or links

--- a/builders/seedprod.mdx
+++ b/builders/seedprod.mdx
@@ -34,6 +34,17 @@ What Respira cannot do yet:
 
 Native write support for SeedProd is on the roadmap for a follow-up release.
 
+## Write hazards
+
+None, because there are no writes. SeedProd is the one builder in the list where a write cannot go wrong, since `inject_content` and `create_code_block` return a clear "not supported" error instead of attempting anything. That refusal is deliberate: a half-implemented writer on a landing page is worse than no writer.
+
+Two things worth knowing anyway:
+
+- **SeedProd registers no separate global token store**, so design-token work reports nothing for it rather than writing tokens into a store SeedProd never reads.
+- **Everything else on your site still writes normally.** Only the SeedProd landing pages themselves are read and audit only.
+
+If write support ships, the hazards on this page will be filled in the same way as every other builder. See [Write hazards](/builders/overview#write-hazards) on the overview page for what that means.
+
 ## FAQ
 
 ### Can Respira edit my SeedProd landing pages?

--- a/builders/spectra.mdx
+++ b/builders/spectra.mdx
@@ -40,6 +40,30 @@ Prime once at the start of a session so the agent builds and edits in blocks, no
 
 The workflow is the same as core Gutenberg because Spectra blocks are just namespaced WordPress blocks. For the shared block workflow, block identification, and prompt patterns, see [Gutenberg (Block Editor)](/builders/gutenberg).
 
+## Write hazards
+
+Spectra blocks are namespaced WordPress blocks, so every hazard in the [Gutenberg write hazards](/builders/gutenberg#write-hazards) section applies here unchanged. The one worth knowing by heart:
+
+### An `attributes` patch merged onto the block root
+
+**What goes wrong.** A block's attribute bag is called `attrs` in the stored markup. The shared update path treated a payload key named `attributes` as already being in the right place, which is true only for builders whose bucket is literally called that. The patch was merged onto the block root, where the serializer never looks. `attributes` is the vocabulary the WordPress block API itself teaches, so it is the natural thing to write.
+
+**What you see.** `write_was_noop: true` on a response that otherwise reads as successful, and a page that comes back byte-identical. Content updates on the same block worked, which is what made it look like a per-block problem.
+
+**Status.** Fixed in 8.6.28, for every builder that inherits the block path.
+
+**What to do.** Read `write_was_noop` on every write. On any version, that field is the tell that a write reported success and moved nothing.
+
+### The intelligence layer reporting as unavailable
+
+**What goes wrong.** The check that reports whether a builder has an intelligence package derived the package directory from the builder's display name, so the block-vendor builders went looking for directories that do not and should not exist. The block package reads the live block registry, so it already covered every block these builders register.
+
+**What you see.** The builder info screen reporting no intelligence layer for Spectra. Cosmetic: the capability was there the whole time.
+
+**Status.** Fixed in 8.2.1 for Spectra, Kadence Blocks, GenerateBlocks and GreenShift by inheritance.
+
+**What to do.** Nothing.
+
 ## FAQ
 
 ### Does Respira edit Spectra blocks natively or convert them?

--- a/builders/thrive-architect.mdx
+++ b/builders/thrive-architect.mdx
@@ -139,6 +139,40 @@ Thrive's Smart Landing Pages work with Respira for content updates while preserv
 - **Animations**: Entry effects and hover animations are preserved but need the builder
 - **Global elements**: Thrive Architect global elements can be edited but changes need verification
 
+## Write hazards
+
+Reproduced ways a Thrive Architect write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### Structural changes are not written, by design
+
+**What goes wrong.** Thrive stores rendered HTML, not a structured tree. Respira only replaces text inside the elements that already exist on the page, in the order they appear. A payload that adds, removes or re-nests elements is not something this path can honour.
+
+**What you see.** If your payload carries a different number of text nodes than the page has, the write is refused with `respira_thrive_structure_change` and a message naming both counts: "Thrive Architect text-node count mismatch (page has 12, request has 9)". If your payload carries no text nodes at all, the stored HTML is returned unchanged and the write reports `write_was_noop: true`.
+
+**Status.** Working as designed, not a defect, and not scheduled to change. Thrive is text edits only.
+
+**What to do.** Open Thrive Architect to add or remove elements. Use Respira for the wording once the structure exists.
+
+### The editor and the front end can disagree
+
+**What goes wrong.** Thrive keeps two copies of the page: `tve_updated_post`, which is what the front end renders, and `tve_updated_post_unfiltered`, which is the copy Thrive reloads when you re-open the visual editor. Writing only the rendered key makes the change vanish the next time you open the page in Thrive.
+
+**What you see.** A correct front end, and an editor that shows the old text as soon as you open it, silently reverting the change on the next editor save.
+
+**Status.** Both keys are written together on every Respira write, so this does not happen through Respira. It is recorded here because it is the failure mode any other tool writing Thrive meta will hit, and because it explains why a Thrive write touches more than one key.
+
+**What to do.** Nothing. Do not hand-edit `tve_updated_post` on its own.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Thrive stores its page data in post meta (`tve_updated_post`), not in the post body. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Content optimization** - Update headlines, CTAs, and copy for conversion testing

--- a/builders/visual-composer.mdx
+++ b/builders/visual-composer.mdx
@@ -137,6 +137,50 @@ Visual Composer's global areas are editable:
 - **`update_element` applies edits as a deep settings patch.** The base-class write path (shared with Visual Composer) now normalizes an `updates` payload into a settings patch and deep-merges it, instead of a shallow merge at the element root that used to overwrite the whole `settings` dict and lose other styling keys.
 - **Successful meta writes are not misreported as no-ops.** Visual Composer stores its canonical tree in post meta, not `post_content`, so the write-noop check reads a storage-specific signature and no longer flags every successful write as a silent failure.
 
+## Write hazards
+
+Reproduced ways a Visual Composer write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder. Visual Composer Website Builder is a different product from [WPBakery](/builders/wpbakery), and the two do not share these entries.
+
+### An edit landing on the wrong element
+
+**What goes wrong.** Visual Composer pages carry no stable element IDs that survive a rewrite, so targeting is by type, class, path or matched content. Before 8.6.28, `find_element` honoured `match_content` and returned the element you meant, then `update_element` and `remove_element` re-resolved the identifier from scratch without it and acted on the first element of that type on the page.
+
+**What you see.** A search that correctly found the third element, followed by an edit to the first.
+
+**Status.** Fixed in 8.6.28. Both tools accept and honour `match_content`, and a genuinely ambiguous target is refused with `respira_ambiguous_target` and the list of candidates rather than guessed at.
+
+**What to do.** Use a custom class as a targeting handle where you can. It is the most stable identifier this builder offers.
+
+### `duplicate_element` unusable on this builder
+
+**What goes wrong.** The MCP tool exposed a single `element_id` argument while the plugin route has always required `identifier_type` and `identifier_value`. On builders with no stable IDs anywhere, there was no workaround.
+
+**What you see.** "Missing parameter(s): identifier_type, identifier_value" on every duplicate call.
+
+**Status.** Fixed in MCP server 6.19.7. Note this is the MCP server version, not the plugin version.
+
+**What to do.** Update the MCP server as well as the plugin.
+
+### Visual Composer recompiles on its own schedule
+
+**What goes wrong.** Nothing in Respira. Visual Composer keeps a self-compiled copy of the page in `post_content` alongside its real storage, and it recompiles that copy on the next save inside its own editor. Restores re-mint element ids, so a raw content comparison after a restore is only ever semantic, never byte-for-byte.
+
+**What you see.** A correct write whose front-end output only fully settles after the next editor save.
+
+**Status.** Not a defect. Visual Composer moved from read to write in 7.4.0 "Clearing" with this caveat stated at the time.
+
+**What to do.** Open and save the page in Visual Composer once after a structural change.
+
+### An empty rollback baseline on duplicates created before 8.6.28
+
+**What goes wrong.** Visual Composer stores its page data in post meta. A duplicate's baseline snapshot used to be captured before that meta was copied onto the new post, so it recorded an empty page.
+
+**What you see.** A restore that reports success and leaves the page exactly as it was.
+
+**Status.** Fixed in 8.6.28. Restoring an empty baseline onto a page that has content is now refused with `respira_snapshot_stale_empty_baseline`.
+
+**What to do.** Re-duplicate anything created before 8.6.28 that you rely on for rollback.
+
 ## When to Use This Tool
 
 - **Content updates** - Change text, links, and images without opening the builder

--- a/builders/wpbakery.mdx
+++ b/builders/wpbakery.mdx
@@ -127,6 +127,50 @@ Respira works with content regardless of which editor was used. Both Backend Edi
 - **`find_builder_targets` paginates.** Results carry `total_matches`, `offset`, `has_more` and `next_offset` so large pages page through cleanly.
 - **`_wpb_shortcodes_custom_css` is regenerated on every inject**, so Respira's REST writes (which run without an editor cap check) no longer leave stale per-post shortcode CSS that could break the front-end render on Uncode.
 
+## Write hazards
+
+Reproduced ways a WPBakery write has gone wrong, and what to do about each. See [Write hazards](/builders/overview#write-hazards) on the overview page for the guards that apply to every builder.
+
+### An edit landing on the wrong element
+
+**What goes wrong.** WPBakery shortcodes have no stable element IDs. `el_id` is optional and user-set, so targeting is by type, class, path or matched content. Before 8.6.28, `find_element` honoured `match_content` and returned the element you meant, then `update_element` and `remove_element` re-resolved the identifier from scratch without it and acted on the first element of that type on the page.
+
+**What you see.** A search that correctly found the third text block, followed by an edit to the first. The reporter of this one had to restore a snapshot.
+
+**Status.** Fixed in 8.6.28. Both tools accept and honour `match_content`, and a genuinely ambiguous target is refused with `respira_ambiguous_target` and the list of candidates. `on_ambiguous_match: "first"` opts back in to the old behaviour explicitly.
+
+**What to do.** Set `el_id` on elements you edit often. On a builder with no stable IDs it is the only exact handle you can create.
+
+### A button added at page root that rendered nothing
+
+**What goes wrong.** WPBakery ignores any element that is not inside a `vc_row` and `vc_column` chain. `add_button` and the other shortcuts appended a bare module node to the top level content array.
+
+**What you see.** A successful write, and no button on the page.
+
+**Status.** Fixed in 7.4.1. Top level non-structural nodes are wrapped in the required row and column automatically.
+
+**What to do.** Nothing on 7.4.1 or later.
+
+### A snapshot restore that changed the page it restored
+
+**What goes wrong.** Restore used to re-apply the content through the inject path, which re-serialises shortcodes. That pass re-encoded attributes, shifted column widths and re-ordered attributes, so the restored page was not byte-identical to what was captured.
+
+**What you see.** A restore that reports success, followed by a builder hash that does not match the snapshot's. The page is close but not the same.
+
+**Status.** Fixed in 7.4.1. Restore for WPBakery skips the inject pass, the same way Divi 5 and Beaver Builder already did, and `post_content` is restored byte-correctly.
+
+**What to do.** Nothing on 7.4.1 or later. If a restore on an older build left the page subtly different, the snapshot payload itself is intact and can be re-applied.
+
+### `duplicate_element` unusable on this builder
+
+**What goes wrong.** The MCP tool exposed a single `element_id` argument while the plugin route has always required `identifier_type` and `identifier_value`. On builders with stable IDs this was one 400 error. On WPBakery, where nothing has a stable ID, there was no workaround at all.
+
+**What you see.** "Missing parameter(s): identifier_type, identifier_value" on every duplicate call.
+
+**Status.** Fixed in MCP server 6.19.7, which exposes both arguments directly and keeps `element_id` as a back-compat alias. Note this is the MCP server version, not the plugin version.
+
+**What to do.** Update the MCP server, not just the plugin. They release on separate lines.
+
 ## When to Use This Tool
 
 - **Content updates** - Change text, links, and images without opening the builder


### PR DESCRIPTION
Closes the long-standing ask for honest per-builder write-hazard documentation (ticket `e35d5f24`).

That ticket was explicitly blocked on *"once repro cases are collected from real sites."* They have been. The 2026-08-19 bug queue reproduced and fixed several, each with a regression test, so there is finally enough verified material to write this from evidence rather than from memory.

### What this adds

- **18 builder pages** gain a `## Write hazards` section in one consistent shape: **What goes wrong / What you see / Status / What to do.**
- **`overview.mdx`** gains a framing section: the three shapes a write hazard takes (silent no-op, wrong target, damaging write) and the five guards against them (duplicate-first, snapshots, render validation, refusal over guessing, write receipts). It states plainly that no guard was designed in advance; each exists because of a specific failure, and each entry names it.
- Three pages carry an honest "hazards this builder does not have" note, so a reader stops looking instead of assuming the section is unfinished.

670 lines added, no new files, so no nav change.

### Why "What you see" is the load-bearing line

Most of these are silent by nature. The write reports success and the damage only appears on read-back or on the front end. A hazard with no observable symptom does not help somebody trying to work out whether it is happening to them right now. So every entry names an error code, a rendered symptom, or a read-back shape.

### Accuracy

- Every version cited was checked against the plugin CHANGELOG **on the `v8.6.31` tag**, not a working tree, since working trees lag the released lineage.
- Three version numbers were wrong on the first pass and were corrected: Oxygen 6 design bucket is **7.5.48**, Beaver detection is **7.5.31**, block-family intelligence is **8.2.1**.
- Error codes were read out of the plugin source, not inferred from changelog prose.
- Only `Callout` is used, with `kind` values already in use elsewhere in this repo.

### Deliberately left out

Several hazards from the internal builder notes are omitted. They are real as far as those notes go, but with no changelog entry, test, or verified customer-visible symptom behind them, documenting them would be assertion rather than documentation. They are listed in the working notes for a later pass.

### One thing to confirm on review

Eight cross-page links assume the site's anchor generation turns `## Write hazards` into `#write-hazards`. Worth a click-through on the preview.
